### PR TITLE
Updating workflow to get position and velocity from orbital params, adding ability to simulate body-frame spacecraft thrust profiles, adjusting view setting in visualization

### DIFF
--- a/include/Satellite.h
+++ b/include/Satellite.h
@@ -9,6 +9,26 @@ const double G=6.674*pow(10,-11); //https://en.wikipedia.org/wiki/Gravitational_
 const double mass_Earth=5.9722*pow(10,24); //https://en.wikipedia.org/wiki/Earth_mass
 const double radius_Earth=6378137; //https://en.wikipedia.org/wiki/Earth_radius
 
+class ThrustProfileLVLH
+{
+    public:
+        double t_start_={0};
+        double t_end_={0};
+        std::array<double,3> LVLH_force_vec_={0,0,0};
+        ThrustProfileLVLH(double t_start, double t_end, std::array<double,3> LVLH_force_vec){
+            t_start_=t_start;
+            t_end_=t_end;
+            LVLH_force_vec_=LVLH_force_vec;
+        }
+        ThrustProfileLVLH(double t_start, double t_end, std::array<double,3> LVLH_normalized_force_direction_vec,double input_force_magnitude){
+            t_start_=t_start;
+            t_end_=t_end;
+            for (size_t ind=0;ind<3;ind++){
+                LVLH_force_vec_.at(ind)=input_force_magnitude*LVLH_normalized_force_direction_vec.at(ind);
+            }
+        }
+};
+
 class Satellite
 {
     private:
@@ -19,8 +39,15 @@ class Satellite
         double a_={0};
         double true_anomaly_={0};
         double orbital_period_={0};
-        double m_={0};
+        double m_={1}; //default value to prevent infinities in acceleration calculations from a=F/m
         double t_={0};
+
+
+        //Now body-frame attributes
+        double pitch_angle_={0};
+        double roll_angle_={0};
+        double yaw_angle_={0};
+
         std::string name_="";
 
         std::array<double,3> perifocal_position_={0,0,0};
@@ -28,6 +55,12 @@ class Satellite
 
         std::array<double,3> ECI_position_={0,0,0};
         std::array<double,3> ECI_velocity_={0,0,0};
+
+        std::vector<ThrustProfileLVLH> thrust_profile_list_={};
+
+        std::vector<std::array<double,3>> list_of_LVLH_forces_at_this_time_={};
+        std::vector<std::array<double,3>> list_of_ECI_forces_at_this_time_={};
+
 
         std::pair<double,double> calculate_eccentric_anomaly(const double input_eccentricity, const double input_true_anomaly,const double input_semimajor_axis);
         double calculate_orbital_period(double input_semimajor_axis);
@@ -126,5 +159,9 @@ class Satellite
         std::array<double,3> convert_perifocal_to_ECI(std::array<double,3> input_perifocal_vec);
         std::array<double,3> convert_ECI_to_perifocal(std::array<double,3> input_ECI_vec);
 
+        std::array<double,3> convert_LVLH_to_ECI(std::array<double,3> input_LVLH_vec);
+
+        void add_LVLH_thrust_profile(std::array<double,3> input_LVLH_normalized_thrust_direction,double input_LVLH_thrust_magnitude,double input_thrust_start_time, double input_thrust_end_time);
+        void add_LVLH_thrust_profile(std::array<double,3> input_LVLH_thrust_vector,double input_thrust_start_time, double input_thrust_end_time);
 
 };

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,39 +1,45 @@
 #include <iostream>
 #include <functional>
+#include <Eigen/Dense>
 
-std::array<double,3> calculate_orbital_acceleration(const std::array<double,3> input_r_vec);
+using Eigen::Matrix3d;
 
 
-std::array<double,6> RK4_deriv_function_orbit_position_and_velocity(std::array<double,6> input_position_and_velocity);
+std::array<double,3> calculate_orbital_acceleration(const std::array<double,3> input_r_vec,const double input_spacecraft_mass,std::vector<std::array<double,3>> input_vec_of_force_vectors_in_ECI={});
 
-template <int T> std::array<double, T> RK4_step(std::array<double, T> y_n, double input_step_size,std::function<std::array<double,T>(const std::array<double,T> input_y_vec)> input_derivative_function){
+
+std::array<double,6> RK4_deriv_function_orbit_position_and_velocity(std::array<double,6> input_position_and_velocity,const double input_spacecraft_mass,std::vector<std::array<double,3>> input_vec_of_force_vectors_in_ECI={});
+
+template <int T> std::array<double, T> RK4_step(std::array<double, T> y_n, double input_step_size,std::function<std::array<double,T>(const std::array<double,T> input_y_vec,const double input_spacecraft_mass,std::vector<std::array<double,3>> input_vec_of_force_vectors_in_ECI)> input_derivative_function,const double input_spacecraft_mass,std::vector<std::array<double,3>> input_vec_of_force_vectors_in_ECI_at_t={},std::vector<std::array<double,3>> input_vec_of_force_vectors_in_ECI_at_t_and_halfstep={},std::vector<std::array<double,3>> input_vec_of_force_vectors_in_ECI_at_t_and_step={}){
     //ref: https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta_methods#The_Runge%E2%80%93Kutta_method
     std::array<double,T> y_nplus1=y_n;
 
     //first, k=1;
     //going to be assuming derivative function does not have explicit time dependence
-    std::array<double, T> k_1=input_derivative_function(y_n);
+    std::array<double, T> k_1=input_derivative_function(y_n,input_spacecraft_mass,input_vec_of_force_vectors_in_ECI_at_t);
 
     //now k_2
     std::array<double, T> y_vec_for_k_2=y_n;
     for (size_t ind=0;ind<T;ind++){
         y_vec_for_k_2.at(ind)+=( (input_step_size/2) * k_1.at(ind));
     }
-    
-    std::array<double, T> k_2=input_derivative_function(y_vec_for_k_2);
+
+    std::array<double, T> k_2=input_derivative_function(y_vec_for_k_2,input_spacecraft_mass,input_vec_of_force_vectors_in_ECI_at_t_and_halfstep);
     //now k_3
     std::array<double, T> y_vec_for_k_3=y_n;
     for (size_t ind=0;ind<T;ind++){
         y_vec_for_k_3.at(ind)+=( (input_step_size/2) * k_2.at(ind));
     }
-    std::array<double, T> k_3=input_derivative_function(y_vec_for_k_3);
+
+    std::array<double, T> k_3=input_derivative_function(y_vec_for_k_3,input_spacecraft_mass,input_vec_of_force_vectors_in_ECI_at_t_and_halfstep);
 
     //now k_4
     std::array<double, T> y_vec_for_k_4=y_n;
     for (size_t ind=0;ind<T;ind++){
         y_vec_for_k_4.at(ind)+=( input_step_size * k_3.at(ind));
     }
-    std::array<double, T> k_4=input_derivative_function(y_vec_for_k_4);
+
+    std::array<double, T> k_4=input_derivative_function(y_vec_for_k_4,input_spacecraft_mass,input_vec_of_force_vectors_in_ECI_at_t_and_step);
 
     for (size_t ind=0;ind<T;ind++){
         y_nplus1.at(ind)+=( (input_step_size/6) * (k_1.at(ind) + 2*k_2.at(ind) + 2*k_3.at(ind) + k_4.at(ind)) );
@@ -44,3 +50,11 @@ template <int T> std::array<double, T> RK4_step(std::array<double, T> y_n, doubl
 
 
 void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,double input_timestep, double input_total_sim_time);
+
+Matrix3d z_rot_matrix(double input_angle);
+
+Matrix3d y_rot_matrix(double input_angle);
+
+Matrix3d x_rot_matrix(double input_angle);
+
+

--- a/input.json
+++ b/input.json
@@ -1,5 +1,5 @@
 {
-    "Inclination": 0,
+    "Inclination": 45,
     "RAAN": 1,
     "Argument of Periapsis": 1,
     "Eccentricity": 0.1,

--- a/input.json
+++ b/input.json
@@ -1,12 +1,12 @@
 {
-    "Inclination": 45,
+    "Inclination": 0,
     "RAAN": 1,
     "Argument of Periapsis": 1,
     "Eccentricity": 0.1,
     "Semimajor Axis": 10000,
     "True Anomaly": 0,
     "Mass": 100,
-    "Name" : "Test Satellite Name 1",
+    "Name" : "Satellite 1",
     "Plotting Color" : "dark-goldenrod"
 
 }

--- a/input_2.json
+++ b/input_2.json
@@ -2,10 +2,11 @@
     "Inclination": 0,
     "RAAN": 1,
     "Argument of Periapsis": 1,
-    "Eccentricity": 0.5,
-    "Semimajor Axis": 15000,
-    "True Anomaly": 90,
+    "Eccentricity": 0.1,
+    "Semimajor Axis": 10000,
+    "True Anomaly": 0,
     "Mass": 100,
-    "Name" : "Test Satellite Name 2",
-    "Plotting Color": "dark-magenta"
+    "Name" : "Satellite 2",
+    "Plotting Color" : "forest-green"
+
 }

--- a/input_2.json
+++ b/input_2.json
@@ -2,9 +2,10 @@
     "Inclination": 0,
     "RAAN": 1,
     "Argument of Periapsis": 1,
-    "Eccentricity": 0.0,
+    "Eccentricity": 0.5,
     "Semimajor Axis": 11000,
     "True Anomaly": 90,
     "Mass": 100,
-    "Name" : "Test Satellite Name 2"
+    "Name" : "Test Satellite Name 2",
+    "Plotting Color": "dark-magenta"
 }

--- a/input_2.json
+++ b/input_2.json
@@ -3,7 +3,7 @@
     "RAAN": 1,
     "Argument of Periapsis": 1,
     "Eccentricity": 0.5,
-    "Semimajor Axis": 11000,
+    "Semimajor Axis": 15000,
     "True Anomaly": 90,
     "Mass": 100,
     "Name" : "Test Satellite Name 2",

--- a/input_3.json
+++ b/input_3.json
@@ -1,0 +1,11 @@
+{
+    "Inclination": 45,
+    "RAAN": 1,
+    "Argument of Periapsis": 1,
+    "Eccentricity": 0.2,
+    "Semimajor Axis": 15000,
+    "True Anomaly": 90,
+    "Mass": 100,
+    "Name" : "Satellite 3",
+    "Plotting Color": "dark-magenta"
+}

--- a/src/Satellite.cpp
+++ b/src/Satellite.cpp
@@ -6,6 +6,7 @@
 #include "Satellite.h"
 #include "utils.h"
 using Eigen::Matrix3d;
+using Eigen::Vector3d;
 
 
 //Currently baselining use of cartesian coordinates in ECI frame (J2000 specifically, if that comes up later)
@@ -30,79 +31,129 @@ std::pair<double,double> Satellite::calculate_eccentric_anomaly(const double inp
     return output_pair;
 }
 
-std::array<double,3> Satellite::transform_orbital_plane_coords_to_3D_ECI_cartesian(double input_x, double input_y,double input_RAAN,double input_i,double input_arg_of_periapsis){
-    //https://en.wikipedia.org/wiki/Orbital_elements#Euler_angle_transformations
-    
-    Matrix3d mat1 {
-        {cos(input_RAAN),-sin(input_RAAN),0},
-        {sin(input_RAAN),cos(input_RAAN),0},
-        {0,0,1}
-    };
-    Matrix3d mat2 {
-        {1,0,0},
-        {0,cos(input_i),-sin(input_i)},
-        {0,sin(input_i),cos(input_i)}
-    };
-    Matrix3d mat3 {
-        {cos(input_arg_of_periapsis),-sin(input_arg_of_periapsis),0},
-        {sin(input_arg_of_periapsis),cos(input_arg_of_periapsis),0},
-        {0,0,1}
-    };
 
-    Matrix3d transformation_matrix;
-    transformation_matrix=mat1*mat2*mat3;
+std::array<double,3> Satellite::calculate_perifocal_position(){
+    //Using approach from Fundamentals of Astrodynamics
+    std::array<double,3> calculated_perifocal_position;
+    double mu=G*mass_Earth;
 
-    double transformed_x_coord=transformation_matrix(0,0)*input_x + transformation_matrix(0,1)*input_y;
-    double transformed_y_coord=transformation_matrix(1,0)*input_x + transformation_matrix(1,1)*input_y;
-    double transformed_z_coord=transformation_matrix(2,0)*input_x + transformation_matrix(2,1)*input_y;
+    double p=a_*(1-eccentricity_)*(1+eccentricity_); //rearranging eq. 1-47
 
-    std::array<double,3> ECI_cartesian_coords={transformed_x_coord,transformed_y_coord,transformed_z_coord};
-    return ECI_cartesian_coords;
+    double r=p/(1+eccentricity_*cos(true_anomaly_));
+
+    double r_perifocal_P=r*cos(true_anomaly_);
+    double r_perifocal_Q=r*sin(true_anomaly_);
+
+    calculated_perifocal_position.at(0)=r_perifocal_P;
+    calculated_perifocal_position.at(1)=r_perifocal_Q;
+    calculated_perifocal_position.at(2)=0; //W component is 0 
+
+    return calculated_perifocal_position;
+}
+
+std::array<double,3> Satellite::calculate_perifocal_velocity(){
+    //Using approach from Fundamentals of Astrodynamics
+    std::array<double,3> calculated_perifocal_velocity;
+    double mu=G*mass_Earth;
+    double p=a_*(1-eccentricity_)*(1+eccentricity_); //rearranging eq. 1-47
+
+    double v_perifocal_P=sqrt(mu/p)*(-sin(true_anomaly_));
+    double v_perifocal_Q=sqrt(mu/p)*(eccentricity_+cos(true_anomaly_));
+
+    calculated_perifocal_velocity.at(0)=v_perifocal_P;
+    calculated_perifocal_velocity.at(1)=v_perifocal_Q;
+    calculated_perifocal_velocity.at(2)=0; //0 component in the W direction
+
+    return calculated_perifocal_velocity;
+}
+
+
+std::array<double,3> Satellite::convert_perifocal_to_ECI(std::array<double,3> input_perifocal_vec){
+    //method from Fundamentals of Astrodynamics
+    //sounds like what they describe as their "Geocentric-Equatorial" coordinate system is ECI
+    Matrix3d R_tilde_matrix;
+
+    R_tilde_matrix(0,0)=cos(raan_)*cos(arg_of_periapsis_)-sin(raan_)*sin(arg_of_periapsis_)*cos(inclination_);
+
+    R_tilde_matrix(0,1)=-cos(raan_)*sin(arg_of_periapsis_) - sin(raan_)*cos(arg_of_periapsis_)*cos(inclination_);
+
+    R_tilde_matrix(0,2)=sin(raan_)*sin(inclination_);
+
+    R_tilde_matrix(1,0)=sin(raan_)*cos(arg_of_periapsis_) + cos(raan_)*sin(arg_of_periapsis_)*cos(inclination_);
+
+    R_tilde_matrix(1,1)=-sin(raan_)*sin(arg_of_periapsis_) + cos(raan_)*cos(arg_of_periapsis_)*cos(inclination_);
+
+    R_tilde_matrix(1,2) = -cos(raan_)*sin(inclination_);
+
+    R_tilde_matrix(2,0)=sin(arg_of_periapsis_)*sin(inclination_);
+
+    R_tilde_matrix(2,1)= cos(arg_of_periapsis_)*sin(inclination_);
+
+    R_tilde_matrix(2,2) = cos(inclination_);
+
+    //convert to Eigen vectors just to make sure matrix-vector multiplication is done correctly
+    Vector3d vector_ijk(0,0,0);
+    Vector3d vector_pqw(0,0,0);
+
+    vector_pqw(0)=input_perifocal_vec.at(0);
+    vector_pqw(1)=input_perifocal_vec.at(1);
+    vector_pqw(2)=input_perifocal_vec.at(2);
+
+
+    vector_ijk=R_tilde_matrix*vector_pqw;
+    std::array<double,3> output_vector_ijk={vector_ijk(0),vector_ijk(1),vector_ijk(2)};
+
+    return output_vector_ijk;
 }
 
 
 
-std::pair<std::array<double,3>,std::array<double,3>> Satellite::calculate_position_and_velocity_from_orbit_params(const double input_semimajor_axis,const double input_eccentricity,const double input_true_anomaly,const double input_RAAN,const double input_i,const double input_arg_of_periapsis,const double input_orbital_period){
-    //Using Kepler's equation to get position from orbital parameters
-    //need mean anomaly to get eccentric anomaly, from which orbital plane positions can be determined
-    //https://en.wikipedia.org/wiki/Kepler%27s_equation
-    std::pair<double,double> output_pair=calculate_eccentric_anomaly(input_eccentricity,input_true_anomaly,input_semimajor_axis);
-    double eccentric_anomaly=output_pair.first;
-    double computed_distance_from_Earth=output_pair.second;
-    double x=input_semimajor_axis*(cos(eccentric_anomaly)-input_eccentricity);
 
-    double b=input_semimajor_axis*sqrt(1-pow(input_eccentricity,2));
-    double y=b*sin(eccentric_anomaly);
-    //but these are x,y coordinates in the orbital plane. Need to convert to 3D cartesian coordinates in ECI
+std::array<double,3> Satellite::convert_ECI_to_perifocal(std::array<double,3> input_ECI_vec){
+    //method from Fundamentals of Astrodynamics, and using https://en.wikipedia.org/wiki/Perifocal_coordinate_system
+    //sounds like what they describe as their "Geocentric-Equatorial" coordinate system is ECI
+    Matrix3d R_tilde_matrix;
 
-    std::array<double,3> ECI_cartesian_coords=transform_orbital_plane_coords_to_3D_ECI_cartesian(x,y,input_RAAN,input_i,input_arg_of_periapsis);
+    R_tilde_matrix(0,0)=cos(raan_)*cos(arg_of_periapsis_)-sin(raan_)*sin(arg_of_periapsis_)*cos(inclination_);
 
-    //https://en.wikipedia.org/wiki/Orbital_speed
-    double distance=sqrt(pow(ECI_cartesian_coords.at(0),2)+pow(ECI_cartesian_coords.at(1),2)+pow(ECI_cartesian_coords.at(2),2));
-    if (abs(distance-computed_distance_from_Earth)>=pow(10,-8)){
-        std::cout << "distance diff was " << abs(distance-computed_distance_from_Earth) << "\n";
-        //these should be the same distance
-    }
-    double initial_speed=sqrt(G*mass_Earth*(2/distance - 1/input_semimajor_axis));
-    //But what's the orbital velocity direction?
+    R_tilde_matrix(0,1)=-cos(raan_)*sin(arg_of_periapsis_) - sin(raan_)*cos(arg_of_periapsis_)*cos(inclination_);
 
-    //http://mae-nas.eng.usu.edu/MAE_5540_Web/propulsion_systems/section2/section2.3.pdf
-    //need to figure out how to calculate omega, the instantaneous rate of change of the true anomaly at that value of true anomaly
-    //from Kepler's second law:
-    double omega=2*pow(input_semimajor_axis,2)*M_PI*sqrt(1-pow(input_eccentricity,2))/(input_orbital_period*pow(distance,2));
+    R_tilde_matrix(0,2)=sin(raan_)*sin(inclination_);
 
-    double v_r_orbital_plane=distance*omega*input_eccentricity*sin(input_true_anomaly)/(1+input_eccentricity*cos(input_true_anomaly));
-    double v_theta_orbital_plane=distance*omega;
-    double v_x_orbital_plane=v_r_orbital_plane*cos(input_true_anomaly) - v_theta_orbital_plane*sin(input_true_anomaly);
-    double v_y_orbital_plane=v_theta_orbital_plane*cos(input_true_anomaly) + v_r_orbital_plane*sin(input_true_anomaly);
+    R_tilde_matrix(1,0)=sin(raan_)*cos(arg_of_periapsis_) + cos(raan_)*sin(arg_of_periapsis_)*cos(inclination_);
 
-    std::array<double,3> ECI_cartesian_velocities=transform_orbital_plane_coords_to_3D_ECI_cartesian(v_x_orbital_plane,v_y_orbital_plane,input_RAAN,input_i,input_arg_of_periapsis);
+    R_tilde_matrix(1,1)=-sin(raan_)*sin(arg_of_periapsis_) + cos(raan_)*cos(arg_of_periapsis_)*cos(inclination_);
 
-    std::pair<std::array<double,3>,std::array<double,3>> output_array;
-    output_array.first=ECI_cartesian_coords;
-    output_array.second=ECI_cartesian_velocities;
-    return output_array;
+    R_tilde_matrix(1,2) = -cos(raan_)*sin(inclination_);
+
+    R_tilde_matrix(2,0)=sin(arg_of_periapsis_)*sin(inclination_);
+
+    R_tilde_matrix(2,1)= cos(arg_of_periapsis_)*sin(inclination_);
+
+    R_tilde_matrix(2,2) = cos(inclination_);
+
+    //convert to Eigen vectors just to make sure matrix-vector multiplication is done correctly
+    Vector3d vector_ijk(0,0,0);
+    Vector3d vector_pqw(0,0,0);
+    vector_ijk(0)=input_ECI_vec.at(0);
+    vector_ijk(1)=input_ECI_vec.at(1);
+    vector_ijk(2)=input_ECI_vec.at(2);
+
+    vector_pqw=(R_tilde_matrix.inverse())*vector_ijk;
+    std::array<double,3> output_vector_pqw={vector_pqw(0),vector_pqw(1),vector_pqw(2)};
+
+    return output_vector_pqw;
 }
+
+
+
+
+
+
+
+
+
+
 
 
 void Satellite::evolve_RK4(double input_step_size){
@@ -111,18 +162,21 @@ void Satellite::evolve_RK4(double input_step_size){
     std::pair<std::array<double,3>,std::array<double,3>> output_position_velocity_pair={};
 
     for (size_t ind=0;ind<3;ind++){
-        combined_initial_position_and_velocity_array.at(ind) = instantaneous_position_.at(ind);
+        combined_initial_position_and_velocity_array.at(ind) = ECI_position_.at(ind);
     }
     for (size_t ind=3;ind<6;ind++){
-        combined_initial_position_and_velocity_array.at(ind) = instantaneous_velocity_.at(ind-3);
+        combined_initial_position_and_velocity_array.at(ind) = ECI_velocity_.at(ind-3);
     }
 
     std::array<double,6> output_combined_initial_position_and_velocity_array= RK4_step<6>(combined_initial_position_and_velocity_array,input_step_size,RK4_deriv_function_orbit_position_and_velocity);
     
     
     for (size_t ind=0;ind<3;ind++){
-        instantaneous_position_.at(ind) = output_combined_initial_position_and_velocity_array.at(ind);
-        instantaneous_velocity_.at(ind) = output_combined_initial_position_and_velocity_array.at(ind+3);
+        ECI_position_.at(ind) = output_combined_initial_position_and_velocity_array.at(ind);
+        ECI_velocity_.at(ind) = output_combined_initial_position_and_velocity_array.at(ind+3);
+        //also update the perifocal versions
+        perifocal_position_=convert_ECI_to_perifocal(ECI_position_);
+        perifocal_velocity_=convert_ECI_to_perifocal(ECI_velocity_);
     }
     t_+=input_step_size;
 

--- a/src/orbits_core.cpp
+++ b/src/orbits_core.cpp
@@ -5,12 +5,22 @@
 int main()
 {
     Satellite test_sat_1("../input.json");
+
+    std::array<double,3> LVLH_thrust_direction={-1,0,0};
+    double thrust_magnitude=100; //N
+    double t_thrust_start=5000;
+    double t_thrust_end=6000;
+    test_sat_1.add_LVLH_thrust_profile(LVLH_thrust_direction,thrust_magnitude,t_thrust_start,t_thrust_end);
+
+
     Satellite test_sat_2("../input_2.json");
 
-    std::vector<Satellite> satellite_vector={test_sat_1,test_sat_2};
+    Satellite test_sat_3("../input_3.json");
+    
+    std::vector<Satellite> satellite_vector={test_sat_1,test_sat_2,test_sat_3};
 
     double timestep=2;
-    double total_sim_time=10000;
+    double total_sim_time=25000;
     sim_and_draw_orbit_gnuplot(satellite_vector,timestep,total_sim_time);
 
     return 0;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -130,7 +130,7 @@ void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,do
         //now the orbit data, inline, one satellite at a time
         for (size_t satellite_index=0;satellite_index<input_satellite_vector.size();satellite_index++){
             Satellite current_satellite=input_satellite_vector.at(satellite_index);
-            std::array<double,3> initial_position=current_satellite.get_position();
+            std::array<double,3> initial_position=current_satellite.get_ECI_position();
             fprintf(gnuplot_pipe,"%f %f %f\n",initial_position.at(0),initial_position.at(1),initial_position.at(2));
     
     
@@ -140,7 +140,7 @@ void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,do
     
             for (int timestep=0;timestep<num_timesteps;timestep++){
                 current_satellite.evolve_RK4(input_timestep);
-                evolved_position=current_satellite.get_position();
+                evolved_position=current_satellite.get_ECI_position();
                 fprintf(gnuplot_pipe,"%f %f %f\n",evolved_position.at(0),evolved_position.at(1),evolved_position.at(2));
             }
             fprintf(gnuplot_pipe,"e\n");

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,16 +1,22 @@
 #include <iostream>
 #include <cmath>
 #include "Satellite.h"
+#include <Eigen/Dense>
+
+using Eigen::Matrix3d;
 //baselining cartesian coordinates in ECI frame
 
-std::array<double,3> calculate_orbital_acceleration(const std::array<double,3> input_r_vec)
+std::array<double,3> calculate_orbital_acceleration(const std::array<double,3> input_r_vec,const double input_spacecraft_mass,std::vector<std::array<double,3>> input_vec_of_force_vectors_in_ECI)
 {
     //orbital acceleration = -G m_Earth/distance^3 * r_vec (just based on rearranging F=ma with a the acceleration due to gravitational attraction between satellite and Earth https://en.wikipedia.org/wiki/Newton%27s_law_of_universal_gravitation)
     //going to be assuming Earth's position doesn't change for now
     //also assuming Earth is spherical, can loosen this assumption in the future
-    std::array<double,3> acceleration_vec=input_r_vec; //shouldn't need to explicitly call copy function because input_r_vec is passed by value not ref
-    
+    //note: this is in ECI frame
 
+    std::array<double,3> acceleration_vec_due_to_gravity=input_r_vec; //shouldn't need to explicitly call copy function because input_r_vec is passed by value not ref
+    
+    //F=ma
+    //a=F/m = (F_grav + F_ext)/m = (F_grav/m) + (F_ext/m) = -G*M_Earth/distance^3 + ...
 
     const double distance=sqrt(input_r_vec.at(0)*input_r_vec.at(0) + input_r_vec.at(1)*input_r_vec.at(1) + input_r_vec.at(2)*input_r_vec.at(2));
     const double overall_factor= -G*mass_Earth/pow(distance,3);
@@ -18,13 +24,33 @@ std::array<double,3> calculate_orbital_acceleration(const std::array<double,3> i
 
 
     for (size_t ind=0;ind<input_r_vec.size();ind++){
-        acceleration_vec.at(ind)*=overall_factor;
+        acceleration_vec_due_to_gravity.at(ind)*=overall_factor;
     }
 
+    //now add effects from externally-applied forces, e.g., thrusters, if any
+    std::array<double,3> acceleration_vec=acceleration_vec_due_to_gravity;
+
+    for (std::array<double,3> external_force_vec_in_ECI : input_vec_of_force_vectors_in_ECI){
+        acceleration_vec.at(0)+=(external_force_vec_in_ECI.at(0)/input_spacecraft_mass);
+        acceleration_vec.at(1)+=(external_force_vec_in_ECI.at(1)/input_spacecraft_mass);
+        acceleration_vec.at(2)+=(external_force_vec_in_ECI.at(2)/input_spacecraft_mass);
+    }
     return acceleration_vec;
 }
 
-std::array<double,6> RK4_deriv_function_orbit_position_and_velocity(std::array<double,6> input_position_and_velocity){
+
+
+
+
+
+
+
+
+
+
+
+
+std::array<double,6> RK4_deriv_function_orbit_position_and_velocity(std::array<double,6> input_position_and_velocity,const double input_spacecraft_mass,std::vector<std::array<double,3>> input_vec_of_force_vectors_in_ECI){
     std::array<double,6> derivative_of_input_y={};
     std::array<double,3> position_array={};
 
@@ -33,7 +59,7 @@ std::array<double,6> RK4_deriv_function_orbit_position_and_velocity(std::array<d
         position_array.at(ind)=input_position_and_velocity.at(ind);
     }
     
-    std::array<double,3> calculated_orbital_acceleration=calculate_orbital_acceleration(position_array);
+    std::array<double,3> calculated_orbital_acceleration=calculate_orbital_acceleration(position_array,input_spacecraft_mass,input_vec_of_force_vectors_in_ECI);
 
     for (size_t ind=3;ind<6;ind++){
         derivative_of_input_y.at(ind)=calculated_orbital_acceleration.at(ind-3);
@@ -158,4 +184,35 @@ void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,do
     }
 
     return;
+}
+
+
+
+
+Matrix3d z_rot_matrix(double input_angle){
+    Matrix3d z_rotation_matrix;
+    z_rotation_matrix << cos(input_angle), -sin(input_angle), 0,
+                 sin(input_angle), cos(input_angle), 0,
+                 0,0,1;
+
+    return z_rotation_matrix;
+}
+
+Matrix3d y_rot_matrix(double input_angle){
+    Matrix3d y_rotation_matrix;
+    y_rotation_matrix << cos(input_angle), 0, sin(input_angle),
+                        0,1,0,
+                        -sin(input_angle), 0, cos(input_angle);
+
+    return y_rotation_matrix;
+}
+
+
+Matrix3d x_rot_matrix(double input_angle){
+    Matrix3d x_rotation_matrix;
+    x_rotation_matrix << 1,0,0,
+                         0, cos(input_angle), -sin(input_angle),
+                         0, sin(input_angle), cos(input_angle);
+
+    return x_rotation_matrix;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -64,7 +64,9 @@ void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,do
         fprintf(gnuplot_pipe,"set ylabel 'y'\n");
         fprintf(gnuplot_pipe,"set zlabel 'z'\n");
         fprintf(gnuplot_pipe,"set title 'Simulated orbits up to time %.2f s'\n",input_total_sim_time);
-        fprintf(gnuplot_pipe,"set view 70,1\n");        
+        // fprintf(gnuplot_pipe,"set view 70,1\n");        
+        fprintf(gnuplot_pipe,"set view equal xyz\n");        
+
         fprintf(gnuplot_pipe,"unset colorbox\n");    
         fprintf(gnuplot_pipe,"set style fill transparent solid 1.0\n");    
 


### PR DESCRIPTION
# Context
I wanted to try the workflow of obtaining ECI position and velocity vectors from orbital parameters described in "Fundamentals of Astrodynamics", and I wanted to add the ability to simulate thrusters on the spacecraft, which required introducing the concept of a body frame (I'm using LVLH here). For now, only constant-thrust profiles are supported.

# Changes
Setting unit length in all directions to be equal in visualization (fixed an issue of the Earth rendering non-spherically when inclination was introduced to orbits)

Updated workflow of obtaining position and velocity vectors in ECI frame to that described in Fundamentals of Astrodynamics book

Added the ability to add thrust profiles (in their LVLH frame) to simulated spacecraft, allowing for constant-thrust burns in specified directions for specified periods of time

# Integration Tests
Needs to pass existing unit tests