### PR TITLE
Adding roll, pitch, and yaw angles to satellite initialization, also adding second thrust profile to demonstration workflow

### DIFF
--- a/include/Satellite.h
+++ b/include/Satellite.h
@@ -95,6 +95,21 @@ class Satellite
             //convert to radians
             true_anomaly_*=(M_PI/180);
 
+
+            pitch_angle_=input_data.at("Pitch Angle");
+            //convert to radians
+            pitch_angle_*=(M_PI/180);
+
+            roll_angle_=input_data.at("Roll Angle");
+            //convert to radians
+            roll_angle_*=(M_PI/180);
+
+
+            yaw_angle_=input_data.at("Yaw Angle");
+            //convert to radians
+            yaw_angle_*=(M_PI/180);
+
+
             m_=input_data.at("Mass");
             name_=input_data.at("Name");
 

--- a/input.json
+++ b/input.json
@@ -5,6 +5,9 @@
     "Eccentricity": 0.1,
     "Semimajor Axis": 10000,
     "True Anomaly": 0,
+    "Roll Angle": 0,
+    "Pitch Angle": 0,
+    "Yaw Angle": 0,
     "Mass": 100,
     "Name" : "Satellite 1",
     "Plotting Color" : "dark-goldenrod"

--- a/input_2.json
+++ b/input_2.json
@@ -5,6 +5,9 @@
     "Eccentricity": 0.1,
     "Semimajor Axis": 10000,
     "True Anomaly": 0,
+    "Roll Angle": 10,
+    "Pitch Angle": 25,
+    "Yaw Angle": 189,
     "Mass": 100,
     "Name" : "Satellite 2"
 

--- a/input_3.json
+++ b/input_3.json
@@ -5,6 +5,9 @@
     "Eccentricity": 0.2,
     "Semimajor Axis": 15000,
     "True Anomaly": 90,
+    "Roll Angle": 0,
+    "Pitch Angle": 10,
+    "Yaw Angle": 300,
     "Mass": 100,
     "Name" : "Satellite 3",
     "Plotting Color": "dark-magenta"

--- a/src/simulation_setup.cpp
+++ b/src/simulation_setup.cpp
@@ -12,6 +12,11 @@ int main()
     double t_thrust_end=6000;
     test_sat_1.add_LVLH_thrust_profile(LVLH_thrust_direction,thrust_magnitude,t_thrust_start,t_thrust_end);
 
+    std::array<double,3> LVLH_thrust_vec_2={0.51,20,-5};
+    double t_thrust_2_start=5500;
+    double t_thrust_2_end=6500;
+    test_sat_1.add_LVLH_thrust_profile(LVLH_thrust_vec_2,t_thrust_2_start,t_thrust_2_end);
+    
 
     Satellite test_sat_2("../input_2.json");
 

--- a/tests/circular_orbit_test_1_input.json
+++ b/tests/circular_orbit_test_1_input.json
@@ -5,6 +5,9 @@
     "Eccentricity": 0,
     "Semimajor Axis": 9000,
     "True Anomaly": 0,
+    "Roll Angle": 0,
+    "Pitch Angle": 0,
+    "Yaw Angle": 0,
     "Mass": 1,
     "Name": "Circ_Test_1"
 }

--- a/tests/circular_orbit_test_2_input.json
+++ b/tests/circular_orbit_test_2_input.json
@@ -5,6 +5,9 @@
     "Eccentricity": 0.0,
     "Semimajor Axis": 11035,
     "True Anomaly": 350.9,
+    "Roll Angle": 0,
+    "Pitch Angle": 0,
+    "Yaw Angle": 0,
     "Mass": 930,
     "Name": "Circ_Test_2"
 }

--- a/tests/elliptical_orbit_test_1.json
+++ b/tests/elliptical_orbit_test_1.json
@@ -5,6 +5,9 @@
     "Eccentricity": 0.78,
     "Semimajor Axis": 11035,
     "True Anomaly": 0,
+    "Roll Angle": 0,
+    "Pitch Angle": 0,
+    "Yaw Angle": 0,
     "Mass": 930,
     "Name": "Elliptical_Test_1"
 }

--- a/tests/elliptical_orbit_test_2.json
+++ b/tests/elliptical_orbit_test_2.json
@@ -5,6 +5,9 @@
     "Eccentricity": 0.78,
     "Semimajor Axis": 11035,
     "True Anomaly": 180,
+    "Roll Angle": 0,
+    "Pitch Angle": 0,
+    "Yaw Angle": 0,
     "Mass": 930,
     "Name": "Elliptical_Test_2"
 }


### PR DESCRIPTION
# Context
I needed a way for users to manually set body-frame angles (roll, pitch, yaw) to actually incorporate them into simulation

# Context
- Added roll, pitch, and yaw angles as required input parameters in input json files
- Also added second thrust profile to demonstration workflow to show adding multiple

# Integration Tests
Needs to pass existing unit tests