### PR TITLE
Rolling back roll, pitch, yaw for now, calculating transformation between LVLH and ECI frames manually using dot and cross products

### DIFF
--- a/include/Satellite.h
+++ b/include/Satellite.h
@@ -41,13 +41,18 @@ class Satellite
         double true_anomaly_={0};
         double orbital_period_={0};
         double m_={1}; //default value to prevent infinities in acceleration calculations from a=F/m
+        // double I_={1}; //moment of inertia, taken to be same for all 3 principal axes, set to default value for same reasons as mass
         double t_={0};
 
 
         //Now body-frame attributes
-        double pitch_angle_={0};
-        double roll_angle_={0};
-        double yaw_angle_={0};
+        // double pitch_angle_={0};
+        // double roll_angle_={0};
+        // double yaw_angle_={0};
+
+        // double theta_={0};
+        // double phi_={0};
+        // double psi_={0};
 
         std::string name_="";
 
@@ -61,7 +66,7 @@ class Satellite
 
         std::vector<std::array<double,3>> list_of_LVLH_forces_at_this_time_={};
         std::vector<std::array<double,3>> list_of_ECI_forces_at_this_time_={};
-
+        // std::vector<std::array<double,3>> list_of_body_frame_torques_at_this_time_={};
 
         std::pair<double,double> calculate_eccentric_anomaly(const double input_eccentricity, const double input_true_anomaly,const double input_semimajor_axis);
         double calculate_orbital_period(double input_semimajor_axis);
@@ -96,18 +101,18 @@ class Satellite
             true_anomaly_*=(M_PI/180);
 
 
-            pitch_angle_=input_data.at("Pitch Angle");
-            //convert to radians
-            pitch_angle_*=(M_PI/180);
+            // pitch_angle_=input_data.at("Pitch Angle");
+            // //convert to radians
+            // pitch_angle_*=(M_PI/180);
 
-            roll_angle_=input_data.at("Roll Angle");
-            //convert to radians
-            roll_angle_*=(M_PI/180);
+            // roll_angle_=input_data.at("Roll Angle");
+            // //convert to radians
+            // roll_angle_*=(M_PI/180);
 
 
-            yaw_angle_=input_data.at("Yaw Angle");
-            //convert to radians
-            yaw_angle_*=(M_PI/180);
+            // yaw_angle_=input_data.at("Yaw Angle");
+            // //convert to radians
+            // yaw_angle_*=(M_PI/180);
 
 
             m_=input_data.at("Mass");
@@ -175,9 +180,20 @@ class Satellite
         std::array<double,3> convert_perifocal_to_ECI(std::array<double,3> input_perifocal_vec);
         std::array<double,3> convert_ECI_to_perifocal(std::array<double,3> input_ECI_vec);
 
-        std::array<double,3> convert_LVLH_to_ECI(std::array<double,3> input_LVLH_vec);
+        // std::array<double,3> convert_LVLH_to_ECI(std::array<double,3> input_LVLH_vec);
 
         void add_LVLH_thrust_profile(std::array<double,3> input_LVLH_normalized_thrust_direction,double input_LVLH_thrust_magnitude,double input_thrust_start_time, double input_thrust_end_time);
         void add_LVLH_thrust_profile(std::array<double,3> input_LVLH_thrust_vector,double input_thrust_start_time, double input_thrust_end_time);
+        
+
+        std::array<double,3> convert_LVLH_to_ECI_manual(std::array<double,3> input_LVLH_vec);
+        std::array<double,3> convert_ECI_to_LVLH_manual(std::array<double,3> input_ECI_vec);
+
+        // std::array<double,3> convert_body_frame_to_LVLH(std::array<double,3> input_body_frame_vec);
+
+        // std::array<double,3> convert_body_frame_to_LVLH(std::array<double,3> input_body_frame_vec);
+
+        // std::array<double,3> convert_body_frame_to_ECI(std::array<double,3> input_body_frame_vec);
+
 
 };

--- a/include/utils.h
+++ b/include/utils.h
@@ -51,10 +51,12 @@ template <int T> std::array<double, T> RK4_step(std::array<double, T> y_n, doubl
 
 void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,double input_timestep, double input_total_sim_time);
 
-Matrix3d z_rot_matrix(double input_angle);
+// Matrix3d z_rot_matrix(double input_angle);
 
-Matrix3d y_rot_matrix(double input_angle);
+// Matrix3d y_rot_matrix(double input_angle);
 
-Matrix3d x_rot_matrix(double input_angle);
+// Matrix3d x_rot_matrix(double input_angle);
 
+// std::array<double,3> convert_rotated_body_frame_to_unrotated_body_frame(std::array<double,3> input_rotated_body_frame_array,double theta, double phi, double psi);
+// std::array<double,6> RK4_deriv_function_angular(std::array<double,6> input_angular_vec,const double input_spacecraft_MOI,std::vector<std::array<double,3>> input_vec_of_body_frame_torque_vectors);
 

--- a/input.json
+++ b/input.json
@@ -5,9 +5,6 @@
     "Eccentricity": 0.1,
     "Semimajor Axis": 10000,
     "True Anomaly": 0,
-    "Roll Angle": 0,
-    "Pitch Angle": 0,
-    "Yaw Angle": 0,
     "Mass": 100,
     "Name" : "Satellite 1",
     "Plotting Color" : "dark-goldenrod"

--- a/input_2.json
+++ b/input_2.json
@@ -5,9 +5,6 @@
     "Eccentricity": 0.1,
     "Semimajor Axis": 10000,
     "True Anomaly": 0,
-    "Roll Angle": 10,
-    "Pitch Angle": 25,
-    "Yaw Angle": 189,
     "Mass": 100,
     "Name" : "Satellite 2"
 

--- a/input_3.json
+++ b/input_3.json
@@ -5,9 +5,6 @@
     "Eccentricity": 0.2,
     "Semimajor Axis": 15000,
     "True Anomaly": 90,
-    "Roll Angle": 0,
-    "Pitch Angle": 10,
-    "Yaw Angle": 300,
     "Mass": 100,
     "Name" : "Satellite 3",
     "Plotting Color": "dark-magenta"

--- a/src/simulation_setup.cpp
+++ b/src/simulation_setup.cpp
@@ -6,7 +6,7 @@ int main()
 {
     Satellite test_sat_1("../input.json");
 
-    std::array<double,3> LVLH_thrust_direction={-1,0,0};
+    std::array<double,3> LVLH_thrust_direction={1,0,0};
     double thrust_magnitude=100; //N
     double t_thrust_start=5000;
     double t_thrust_end=6000;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -4,6 +4,8 @@
 #include <Eigen/Dense>
 
 using Eigen::Matrix3d;
+using Eigen::Vector3d;
+
 //baselining cartesian coordinates in ECI frame
 
 std::array<double,3> calculate_orbital_acceleration(const std::array<double,3> input_r_vec,const double input_spacecraft_mass,std::vector<std::array<double,3>> input_vec_of_force_vectors_in_ECI)
@@ -67,6 +69,23 @@ std::array<double,6> RK4_deriv_function_orbit_position_and_velocity(std::array<d
 
     return derivative_of_input_y;
 }
+
+
+// std::array<double,6> RK4_deriv_function_angular(std::array<double,6> input_angular_vec,const double input_spacecraft_MOI,std::vector<std::array<double,3>> input_vec_of_body_frame_torque_vectors){
+//     std::array<double,6> derivative_of_input_y={};
+
+//     for (size_t ind=0;ind<3;ind++){
+//         derivative_of_input_y.at(ind)=input_angular_vec.at(ind+3);
+//     }
+    
+//     std::array<double,3> calculated_angular_acceleration=calculate_body_frame_angular_acceleration(input_spacecraft_MOI,input_vec_of_body_frame_torque_vectors);
+
+//     for (size_t ind=3;ind<6;ind++){
+//         derivative_of_input_y.at(ind)=calculated_angular_acceleration.at(ind-3);
+//     }
+
+//     return derivative_of_input_y;
+// }
 
 
 
@@ -189,30 +208,66 @@ void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,do
 
 
 
-Matrix3d z_rot_matrix(double input_angle){
-    Matrix3d z_rotation_matrix;
-    z_rotation_matrix << cos(input_angle), -sin(input_angle), 0,
-                 sin(input_angle), cos(input_angle), 0,
-                 0,0,1;
+// Matrix3d z_rot_matrix(double input_angle){
+//     Matrix3d z_rotation_matrix;
+//     z_rotation_matrix << cos(input_angle), -sin(input_angle), 0,
+//                  sin(input_angle), cos(input_angle), 0,
+//                  0,0,1;
 
-    return z_rotation_matrix;
-}
+//     return z_rotation_matrix;
+// }
 
-Matrix3d y_rot_matrix(double input_angle){
-    Matrix3d y_rotation_matrix;
-    y_rotation_matrix << cos(input_angle), 0, sin(input_angle),
-                        0,1,0,
-                        -sin(input_angle), 0, cos(input_angle);
+// Matrix3d y_rot_matrix(double input_angle){
+//     Matrix3d y_rotation_matrix;
+//     y_rotation_matrix << cos(input_angle), 0, sin(input_angle),
+//                         0,1,0,
+//                         -sin(input_angle), 0, cos(input_angle);
 
-    return y_rotation_matrix;
-}
+//     return y_rotation_matrix;
+// }
 
 
-Matrix3d x_rot_matrix(double input_angle){
-    Matrix3d x_rotation_matrix;
-    x_rotation_matrix << 1,0,0,
-                         0, cos(input_angle), -sin(input_angle),
-                         0, sin(input_angle), cos(input_angle);
+// Matrix3d x_rot_matrix(double input_angle){
+//     Matrix3d x_rotation_matrix;
+//     x_rotation_matrix << 1,0,0,
+//                          0, cos(input_angle), -sin(input_angle),
+//                          0, sin(input_angle), cos(input_angle);
 
-    return x_rotation_matrix;
-}
+//     return x_rotation_matrix;
+// }
+
+
+// std::array<double,3> convert_rotated_body_frame_to_unrotated_body_frame(std::array<double,3> input_rotated_body_frame_array,double theta, double phi, double psi){
+//     Vector3d rotated_body_frame_vec;
+//     rotated_body_frame_vec << input_rotated_body_frame_array.at(0), input_rotated_body_frame_array.at(1), input_rotated_body_frame_array.at(2);
+//     //build A matrix
+//     Matrix3d A_mat;
+//     A_mat << cos(phi)*cos(psi) - cos(theta)*sin(phi)*sin(psi), -cos(phi)*sin(psi) - cos(theta)*sin(phi)*cos(psi), sin(theta)*sin(phi),
+//              sin(phi)*cos(psi) + cos(theta)*cos(phi)*sin(psi), -sin(phi)*sin(psi) + cos(theta)*cos(phi)*cos(psi), -sin(theta)*cos(phi),
+//              sin(theta)*sin(psi), sin(theta)*cos(psi), cos(theta);
+
+//     Vector3d unrotated_body_frame_vec=A_mat*rotated_body_frame_vec;
+//     std::array<double,3> unrotated_body_frame_array;
+//     for (size_t ind=0;ind<3;ind++){
+//         unrotated_body_frame_array.at(ind)=unrotated_body_frame_vec(ind);
+//     }
+//     return unrotated_body_frame_array;
+// }
+
+
+
+
+// std::array<double,3> calculate_body_frame_angular_acceleration(const double input_spacecraft_moi,std::vector<std::array<double,3>> input_vec_of_torque_vectors_in_body_frame)
+// {
+//     //Body-frame angular acceleration calculated from alpha_i=tau_i/I for torque tau, MOI I
+
+//     std::array<double,3> body_frame_angular_acceleration={0,0,0};
+
+//     for (std::array<double,3> body_frame_torque_vec : input_vec_of_torque_vectors_in_body_frame){
+//         for (size_t coord_ind=0;coord_ind<3;coord_ind++){
+//             acceleration_vec.at(coord_ind)+=(body_frame_torque_vec.at(coord_ind)/input_spacecraft_moi);
+//         }
+
+//     }
+//     return body_frame_angular_acceleration;
+// }

--- a/tests/circular_orbit_test_1_input.json
+++ b/tests/circular_orbit_test_1_input.json
@@ -5,9 +5,6 @@
     "Eccentricity": 0,
     "Semimajor Axis": 9000,
     "True Anomaly": 0,
-    "Roll Angle": 0,
-    "Pitch Angle": 0,
-    "Yaw Angle": 0,
     "Mass": 1,
     "Name": "Circ_Test_1"
 }

--- a/tests/circular_orbit_test_2_input.json
+++ b/tests/circular_orbit_test_2_input.json
@@ -5,9 +5,6 @@
     "Eccentricity": 0.0,
     "Semimajor Axis": 11035,
     "True Anomaly": 350.9,
-    "Roll Angle": 0,
-    "Pitch Angle": 0,
-    "Yaw Angle": 0,
     "Mass": 930,
     "Name": "Circ_Test_2"
 }

--- a/tests/elliptical_orbit_test_1.json
+++ b/tests/elliptical_orbit_test_1.json
@@ -5,9 +5,6 @@
     "Eccentricity": 0.78,
     "Semimajor Axis": 11035,
     "True Anomaly": 0,
-    "Roll Angle": 0,
-    "Pitch Angle": 0,
-    "Yaw Angle": 0,
     "Mass": 930,
     "Name": "Elliptical_Test_1"
 }

--- a/tests/elliptical_orbit_test_2.json
+++ b/tests/elliptical_orbit_test_2.json
@@ -5,9 +5,6 @@
     "Eccentricity": 0.78,
     "Semimajor Axis": 11035,
     "True Anomaly": 180,
-    "Roll Angle": 0,
-    "Pitch Angle": 0,
-    "Yaw Angle": 0,
     "Mass": 930,
     "Name": "Elliptical_Test_2"
 }


### PR DESCRIPTION
# Context
I wasn't satisfied with the current state of implementation of roll, pitch, and yaw specifications, so rolling back until I have a better grasp on it (and ideally would like to do a quaternion-based implementation instead). 

# Changes
- Manually calculating the conversion between LVLH and ECI frames using dot products and cross products.
- Rolling back user specification of roll, pitch, yaw in input for now

# Integration Testing
Needs to pass existing unit tests