### PR TITLE
Adding workflow to compute orbital elements from position and velocity

### DIFF
--- a/include/Satellite.h
+++ b/include/Satellite.h
@@ -91,7 +91,13 @@ class Satellite
             //convert to radians
             arg_of_periapsis_*=(M_PI/180);
 
+
             eccentricity_=input_data.at("Eccentricity");
+            //If circular orbit, arg of periapsis is undefined, using convention of setting it to 0 in this case
+            if (eccentricity_==0){
+                arg_of_periapsis_=0;
+            }
+
 
             a_=input_data.at("Semimajor Axis");
             a_*=1000; //converting from km to m
@@ -195,5 +201,7 @@ class Satellite
 
         // std::array<double,3> convert_body_frame_to_ECI(std::array<double,3> input_body_frame_vec);
 
+        void update_orbital_elements_from_position_and_velocity();
+        std::array<double,6> get_orbital_elements();
 
 };

--- a/src/Satellite.cpp
+++ b/src/Satellite.cpp
@@ -213,7 +213,7 @@ void Satellite::evolve_RK4(double input_step_size){
     list_of_ECI_forces_at_this_time_=list_of_ECI_forces_at_one_timestep_past;
 
     //Update orbital parameters
-    update_orbital_elements_from_position_and_velocity();
+    // update_orbital_elements_from_position_and_velocity();
 
     return;
 }

--- a/src/Satellite.cpp
+++ b/src/Satellite.cpp
@@ -213,7 +213,7 @@ void Satellite::evolve_RK4(double input_step_size){
     list_of_ECI_forces_at_this_time_=list_of_ECI_forces_at_one_timestep_past;
 
     //Update orbital parameters
-    // update_orbital_elements_from_position_and_velocity();
+    update_orbital_elements_from_position_and_velocity();
 
     return;
 }

--- a/src/Satellite.cpp
+++ b/src/Satellite.cpp
@@ -377,6 +377,7 @@ std::array<double,3> Satellite::convert_ECI_to_LVLH_manual(std::array<double,3> 
 
 void Satellite::update_orbital_elements_from_position_and_velocity(){
     //Anytime the orbit is changed via external forces, need to update the orbital parameters of the satellite.
+    //True anomaly should change over time even in absence of external forces
     //Using approach from Fundamentals of Astrodynamics
     double mu=G*mass_Earth;
 

--- a/src/Satellite.cpp
+++ b/src/Satellite.cpp
@@ -407,7 +407,6 @@ void Satellite::update_orbital_elements_from_position_and_velocity(){
     }
 
     //Need to treat the e \approx 0 case (circular orbits) specially
-    //Going to set arg of periapsis to be 0 then calculate true anomaly as the argument of latitude instead
     double calculated_arg_of_periapsis;
     double calculated_true_anomaly;
     if (calculated_eccentricity>pow(10,-15)){

--- a/tests/circular_orbit_test_2_input.json
+++ b/tests/circular_orbit_test_2_input.json
@@ -1,7 +1,7 @@
 {
     "Inclination": 23.2,
     "RAAN": 50,
-    "Argument of Periapsis": 29,
+    "Argument of Periapsis": 0,
     "Eccentricity": 0.0,
     "Semimajor Axis": 11035,
     "True Anomaly": 350.9,

--- a/tests/circular_orbit_tests.cpp
+++ b/tests/circular_orbit_tests.cpp
@@ -32,7 +32,7 @@ TEST(CircularOrbitTests,TotalEnergyTimestep1){
     double test_timestep=1; //s
     test_satellite.evolve_RK4(test_timestep);
     double evolved_energy=test_satellite.get_total_energy();
-    EXPECT_TRUE(evolved_energy=-3.35916*pow(10,10)) << "Evolved energy : " << evolved_energy << "\n";
+    EXPECT_TRUE(evolved_energy==-3.35916*pow(10,10)) << "Evolved energy : " << evolved_energy << "\n";
 
     EXPECT_TRUE(abs(initial_energy-evolved_energy)<pow(10,-10)) << "Total energy not preserved within tolerance. Difference: " << initial_energy-evolved_energy << "\n";
 }

--- a/tests/circular_orbit_tests.cpp
+++ b/tests/circular_orbit_tests.cpp
@@ -28,11 +28,11 @@ TEST(CircularOrbitTests,TotalEnergyTimestep1){
 
     Satellite test_satellite("../tests/circular_orbit_test_2_input.json");
     double initial_energy=test_satellite.get_total_energy();
-    std::cout << "Initial energy: " << initial_energy << "\n";
+    EXPECT_TRUE(initial_energy==-3.35916*pow(10,10)) << "Initial energy : " << initial_energy << "\n";
     double test_timestep=1; //s
     test_satellite.evolve_RK4(test_timestep);
     double evolved_energy=test_satellite.get_total_energy();
-    std::cout << "Evolved energy: " << evolved_energy << "\n";
+    EXPECT_TRUE(evolved_energy=-3.35916*pow(10,10)) << "Evolved energy : " << evolved_energy << "\n";
 
     EXPECT_TRUE(abs(initial_energy-evolved_energy)<pow(10,-10)) << "Total energy not preserved within tolerance. Difference: " << initial_energy-evolved_energy << "\n";
 }

--- a/tests/circular_orbit_tests.cpp
+++ b/tests/circular_orbit_tests.cpp
@@ -122,21 +122,21 @@ TEST(CircularOrbitTests,ConstantEvolvedOrbitalElementsTest){
 
 
 
-// TEST(CircularOrbitTests,Thruster_Eccentricity_Change){
+TEST(CircularOrbitTests,Thruster_Eccentricity_Change){
 
-//     Satellite test_satellite("../tests/circular_orbit_test_2_input.json");
-//     std::array<double,3> LVLH_thrust_direction={1,0,0};
-//     double thrust_magnitude=100; //N
-//     double t_thrust_start=1;
-//     double t_thrust_end=100;
+    Satellite test_satellite("../tests/circular_orbit_test_2_input.json");
+    std::array<double,3> LVLH_thrust_direction={1,0,0};
+    double thrust_magnitude=100; //N
+    double t_thrust_start=1;
+    double t_thrust_end=100;
 
-//     test_satellite.add_LVLH_thrust_profile(LVLH_thrust_direction,thrust_magnitude,t_thrust_start,t_thrust_end);
-//     double test_timestep=1; //s
-//     for (int timestep_ind=0;timestep_ind<120;timestep_ind++){
-//         test_satellite.evolve_RK4(test_timestep);
-//     }
-//     std::array<double,6> evolved_orbit_elements=test_satellite.get_orbital_elements();
-//     double resulting_eccentricity=evolved_orbit_elements.at(1);
+    test_satellite.add_LVLH_thrust_profile(LVLH_thrust_direction,thrust_magnitude,t_thrust_start,t_thrust_end);
+    double test_timestep=1; //s
+    for (int timestep_ind=0;timestep_ind<120;timestep_ind++){
+        test_satellite.evolve_RK4(test_timestep);
+    }
+    std::array<double,6> evolved_orbit_elements=test_satellite.get_orbital_elements();
+    double resulting_eccentricity=evolved_orbit_elements.at(1);
 
-//     EXPECT_TRUE(resulting_eccentricity>0) << "Resulting eccentricity was not greater than 0. Calculated value: " << resulting_eccentricity << "\n";
-// }
+    EXPECT_TRUE(resulting_eccentricity>0) << "Resulting eccentricity was not greater than 0. Calculated value: " << resulting_eccentricity << "\n";
+}

--- a/tests/circular_orbit_tests.cpp
+++ b/tests/circular_orbit_tests.cpp
@@ -28,9 +28,12 @@ TEST(CircularOrbitTests,TotalEnergyTimestep1){
 
     Satellite test_satellite("../tests/circular_orbit_test_2_input.json");
     double initial_energy=test_satellite.get_total_energy();
+    std::cout << "Initial energy: " << initial_energy << "\n";
     double test_timestep=1; //s
     test_satellite.evolve_RK4(test_timestep);
     double evolved_energy=test_satellite.get_total_energy();
+    std::cout << "Evolved energy: " << evolved_energy << "\n";
+
     EXPECT_TRUE(abs(initial_energy-evolved_energy)<pow(10,-10)) << "Total energy not preserved within tolerance. Difference: " << initial_energy-evolved_energy << "\n";
 }
 

--- a/tests/circular_orbit_tests.cpp
+++ b/tests/circular_orbit_tests.cpp
@@ -122,21 +122,21 @@ TEST(CircularOrbitTests,ConstantEvolvedOrbitalElementsTest){
 
 
 
-TEST(CircularOrbitTests,Thruster_Eccentricity_Change){
+// TEST(CircularOrbitTests,Thruster_Eccentricity_Change){
 
-    Satellite test_satellite("../tests/circular_orbit_test_2_input.json");
-    std::array<double,3> LVLH_thrust_direction={1,0,0};
-    double thrust_magnitude=100; //N
-    double t_thrust_start=1;
-    double t_thrust_end=100;
+//     Satellite test_satellite("../tests/circular_orbit_test_2_input.json");
+//     std::array<double,3> LVLH_thrust_direction={1,0,0};
+//     double thrust_magnitude=100; //N
+//     double t_thrust_start=1;
+//     double t_thrust_end=100;
 
-    test_satellite.add_LVLH_thrust_profile(LVLH_thrust_direction,thrust_magnitude,t_thrust_start,t_thrust_end);
-    double test_timestep=1; //s
-    for (int timestep_ind=0;timestep_ind<120;timestep_ind++){
-        test_satellite.evolve_RK4(test_timestep);
-    }
-    std::array<double,6> evolved_orbit_elements=test_satellite.get_orbital_elements();
-    double resulting_eccentricity=evolved_orbit_elements.at(1);
+//     test_satellite.add_LVLH_thrust_profile(LVLH_thrust_direction,thrust_magnitude,t_thrust_start,t_thrust_end);
+//     double test_timestep=1; //s
+//     for (int timestep_ind=0;timestep_ind<120;timestep_ind++){
+//         test_satellite.evolve_RK4(test_timestep);
+//     }
+//     std::array<double,6> evolved_orbit_elements=test_satellite.get_orbital_elements();
+//     double resulting_eccentricity=evolved_orbit_elements.at(1);
 
-    EXPECT_TRUE(resulting_eccentricity>0) << "Resulting eccentricity was not greater than 0. Calculated value: " << resulting_eccentricity << "\n";
-}
+//     EXPECT_TRUE(resulting_eccentricity>0) << "Resulting eccentricity was not greater than 0. Calculated value: " << resulting_eccentricity << "\n";
+// }

--- a/tests/circular_orbit_tests.cpp
+++ b/tests/circular_orbit_tests.cpp
@@ -28,13 +28,11 @@ TEST(CircularOrbitTests,TotalEnergyTimestep1){
 
     Satellite test_satellite("../tests/circular_orbit_test_2_input.json");
     double initial_energy=test_satellite.get_total_energy();
-    EXPECT_TRUE(initial_energy==-3.35916*pow(10,10)) << "Initial energy : " << initial_energy << "\n";
     double test_timestep=1; //s
     test_satellite.evolve_RK4(test_timestep);
     double evolved_energy=test_satellite.get_total_energy();
-    EXPECT_TRUE(evolved_energy==-3.35916*pow(10,10)) << "Evolved energy : " << evolved_energy << "\n";
 
-    EXPECT_TRUE(abs(initial_energy-evolved_energy)<pow(10,-10)) << "Total energy not preserved within tolerance. Difference: " << initial_energy-evolved_energy << "\n";
+    EXPECT_TRUE(abs(initial_energy-evolved_energy)<pow(10,-5)) << "Total energy not preserved within tolerance. Difference: " << initial_energy-evolved_energy << "\n";
 }
 
 TEST(CircularOrbitTests,EvolvedOrbitalRadius1){
@@ -45,7 +43,7 @@ TEST(CircularOrbitTests,EvolvedOrbitalRadius1){
     test_satellite.evolve_RK4(test_timestep);
     double calculated_evolved_radius=test_satellite.get_radius();
 
-    EXPECT_TRUE(abs(calculated_initial_radius-calculated_evolved_radius)<pow(10,-10)) << "Orbital radius not constant within tolerance. Difference: " << calculated_initial_radius-calculated_evolved_radius << "\n";
+    EXPECT_TRUE(abs(calculated_initial_radius-calculated_evolved_radius)<pow(10,-8)) << "Orbital radius not constant within tolerance. Difference: " << calculated_initial_radius-calculated_evolved_radius << "\n";
 }
 
 TEST(CircularOrbitTests,EvolvedOrbitalSpeed1){

--- a/tests/circular_orbit_tests.cpp
+++ b/tests/circular_orbit_tests.cpp
@@ -55,3 +55,85 @@ TEST(CircularOrbitTests,EvolvedOrbitalSpeed1){
 
     EXPECT_TRUE(abs(calculated_initial_speed-calculated_evolved_speed)<pow(10,-10)) << "Orbital speed not constant within tolerance. Difference: " << calculated_initial_speed-calculated_evolved_speed << "\n";
 }
+
+
+
+TEST(CircularOrbitTests,BasicOrbitalElementsTest){
+
+    Satellite test_satellite("../tests/circular_orbit_test_2_input.json");
+    std::array<double,6> initial_orbit_elements=test_satellite.get_orbital_elements();
+
+    test_satellite.update_orbital_elements_from_position_and_velocity();
+    std::array<double,6> recalculated_orbit_elements=test_satellite.get_orbital_elements();
+
+    std::array<std::string,6> orbital_element_name_array;
+    orbital_element_name_array.at(0)="Semimajor Axis";
+    orbital_element_name_array.at(1)="Eccentricity";
+    orbital_element_name_array.at(2)="Inclination";
+    orbital_element_name_array.at(3)="RAAN";
+    orbital_element_name_array.at(4)="Argument of Periapsis";
+    orbital_element_name_array.at(5)="True Anomaly";
+
+
+    for (size_t orbital_elem_index=0; orbital_elem_index<6;orbital_elem_index++){
+        if (orbital_elem_index==0){
+            //Setting a different tolerance for semimajor axis than the other orbital parameters since its scale is so different
+            EXPECT_TRUE(abs(initial_orbit_elements.at(orbital_elem_index)-recalculated_orbit_elements.at(orbital_elem_index))<pow(10,-7)) << orbital_element_name_array.at(orbital_elem_index) << " was not constant within tolerance. Diff:" <<initial_orbit_elements.at(orbital_elem_index)-recalculated_orbit_elements.at(orbital_elem_index) << "\n";
+        }
+        else {
+            EXPECT_TRUE(abs(initial_orbit_elements.at(orbital_elem_index)-recalculated_orbit_elements.at(orbital_elem_index))<pow(10,-14)) << orbital_element_name_array.at(orbital_elem_index) << " was not constant within tolerance. Diff:" <<initial_orbit_elements.at(orbital_elem_index)-recalculated_orbit_elements.at(orbital_elem_index) << "\n";
+        }
+    }
+}
+
+TEST(CircularOrbitTests,ConstantEvolvedOrbitalElementsTest){
+
+    Satellite test_satellite("../tests/circular_orbit_test_2_input.json");
+    std::array<double,6> initial_orbit_elements=test_satellite.get_orbital_elements();
+
+    double test_timestep=1; //s
+    test_satellite.evolve_RK4(test_timestep);
+    std::array<double,6> evolved_orbit_elements=test_satellite.get_orbital_elements();
+
+    std::array<std::string,6> orbital_element_name_array;
+    orbital_element_name_array.at(0)="Semimajor Axis";
+    orbital_element_name_array.at(1)="Eccentricity";
+    orbital_element_name_array.at(2)="Inclination";
+    orbital_element_name_array.at(3)="RAAN";
+    orbital_element_name_array.at(4)="Argument of Periapsis";
+    orbital_element_name_array.at(5)="True Anomaly";
+
+
+    for (size_t orbital_elem_index=0; orbital_elem_index<5;orbital_elem_index++){
+        //True anomaly shouldn't be constant over evolution
+        if (orbital_elem_index==0){
+            //Setting a different tolerance for semimajor axis than the other orbital parameters since its scale is so different
+            EXPECT_TRUE(abs(initial_orbit_elements.at(orbital_elem_index)-evolved_orbit_elements.at(orbital_elem_index))<pow(10,-7)) << orbital_element_name_array.at(orbital_elem_index) << " was not constant within tolerance. Diff:" <<initial_orbit_elements.at(orbital_elem_index)-evolved_orbit_elements.at(orbital_elem_index) << "\n";
+        }
+        else {
+            EXPECT_TRUE(abs(initial_orbit_elements.at(orbital_elem_index)-evolved_orbit_elements.at(orbital_elem_index))<pow(10,-14)) << orbital_element_name_array.at(orbital_elem_index) << " was not constant within tolerance. Diff:" <<initial_orbit_elements.at(orbital_elem_index)-evolved_orbit_elements.at(orbital_elem_index) << "\n";
+        }
+    }
+}
+
+
+
+
+TEST(CircularOrbitTests,Thruster_Eccentricity_Change){
+
+    Satellite test_satellite("../tests/circular_orbit_test_2_input.json");
+    std::array<double,3> LVLH_thrust_direction={1,0,0};
+    double thrust_magnitude=100; //N
+    double t_thrust_start=1;
+    double t_thrust_end=100;
+
+    test_satellite.add_LVLH_thrust_profile(LVLH_thrust_direction,thrust_magnitude,t_thrust_start,t_thrust_end);
+    double test_timestep=1; //s
+    for (int timestep_ind=0;timestep_ind<120;timestep_ind++){
+        test_satellite.evolve_RK4(test_timestep);
+    }
+    std::array<double,6> evolved_orbit_elements=test_satellite.get_orbital_elements();
+    double resulting_eccentricity=evolved_orbit_elements.at(1);
+
+    EXPECT_TRUE(resulting_eccentricity>0) << "Resulting eccentricity was not greater than 0. Calculated value: " << resulting_eccentricity << "\n";
+}

--- a/tests/elliptical_orbit_tests.cpp
+++ b/tests/elliptical_orbit_tests.cpp
@@ -25,3 +25,63 @@ TEST(EllipticalOrbitTests,EvolvedOrbitalSpeed2){
 
     EXPECT_TRUE(calculated_initial_speed<calculated_evolved_speed) << "Apogee speed not smaller than calculated evolved speed. Difference: " << calculated_initial_speed-calculated_evolved_speed << "\n";
 }
+
+
+TEST(CircularOrbitTests,ConstantEvolvedOrbitalElementsTest){
+
+    Satellite test_satellite("../tests/elliptical_orbit_test_2.json");
+    std::array<double,6> initial_orbit_elements=test_satellite.get_orbital_elements();
+
+    double test_timestep=1; //s
+    test_satellite.evolve_RK4(test_timestep);
+    std::array<double,6> evolved_orbit_elements=test_satellite.get_orbital_elements();
+
+    std::array<std::string,6> orbital_element_name_array;
+    orbital_element_name_array.at(0)="Semimajor Axis";
+    orbital_element_name_array.at(1)="Eccentricity";
+    orbital_element_name_array.at(2)="Inclination";
+    orbital_element_name_array.at(3)="RAAN";
+    orbital_element_name_array.at(4)="Argument of Periapsis";
+    orbital_element_name_array.at(5)="True Anomaly";
+
+
+    for (size_t orbital_elem_index=0; orbital_elem_index<5;orbital_elem_index++){
+        //True anomaly shouldn't be constant over evolution
+        if (orbital_elem_index==0){
+            //Setting a different tolerance for semimajor axis than the other orbital parameters since its scale is so different
+            EXPECT_TRUE(abs(initial_orbit_elements.at(orbital_elem_index)-evolved_orbit_elements.at(orbital_elem_index))<pow(10,-7)) << orbital_element_name_array.at(orbital_elem_index) << " was not constant within tolerance. Diff:" <<initial_orbit_elements.at(orbital_elem_index)-evolved_orbit_elements.at(orbital_elem_index) << "\n";
+        }
+        else {
+            EXPECT_TRUE(abs(initial_orbit_elements.at(orbital_elem_index)-evolved_orbit_elements.at(orbital_elem_index))<pow(10,-14)) << orbital_element_name_array.at(orbital_elem_index) << " was not constant within tolerance. Diff:" <<initial_orbit_elements.at(orbital_elem_index)-evolved_orbit_elements.at(orbital_elem_index) << "\n";
+        }
+    }
+}
+
+TEST(CircularOrbitTests,BasicOrbitalElementsTest){
+
+    Satellite test_satellite("../tests/elliptical_orbit_test_2.json");
+    std::array<double,6> initial_orbit_elements=test_satellite.get_orbital_elements();
+
+    test_satellite.update_orbital_elements_from_position_and_velocity();
+    std::array<double,6> recalculated_orbit_elements=test_satellite.get_orbital_elements();
+
+    std::array<std::string,6> orbital_element_name_array;
+    orbital_element_name_array.at(0)="Semimajor Axis";
+    orbital_element_name_array.at(1)="Eccentricity";
+    orbital_element_name_array.at(2)="Inclination";
+    orbital_element_name_array.at(3)="RAAN";
+    orbital_element_name_array.at(4)="Argument of Periapsis";
+    orbital_element_name_array.at(5)="True Anomaly";
+
+
+
+    for (size_t orbital_elem_index=0; orbital_elem_index<6;orbital_elem_index++){
+        if (orbital_elem_index==0){
+            //Setting a different tolerance for semimajor axis than the other orbital parameters since its scale is so different
+            EXPECT_TRUE(abs(initial_orbit_elements.at(orbital_elem_index)-recalculated_orbit_elements.at(orbital_elem_index))<pow(10,-7)) << orbital_element_name_array.at(orbital_elem_index) << " was not constant within tolerance. Diff:" <<initial_orbit_elements.at(orbital_elem_index)-recalculated_orbit_elements.at(orbital_elem_index) << "\n";
+        }
+        else {
+            EXPECT_TRUE(abs(initial_orbit_elements.at(orbital_elem_index)-recalculated_orbit_elements.at(orbital_elem_index))<pow(10,-14)) << orbital_element_name_array.at(orbital_elem_index) << " was not constant within tolerance. Diff:" <<initial_orbit_elements.at(orbital_elem_index)-recalculated_orbit_elements.at(orbital_elem_index) << "\n";
+        }
+    }
+}

--- a/tests/elliptical_orbit_tests.cpp
+++ b/tests/elliptical_orbit_tests.cpp
@@ -27,7 +27,7 @@ TEST(EllipticalOrbitTests,EvolvedOrbitalSpeed2){
 }
 
 
-TEST(CircularOrbitTests,ConstantEvolvedOrbitalElementsTest){
+TEST(EllipticalOrbitTests,ConstantEvolvedOrbitalElementsTest){
 
     Satellite test_satellite("../tests/elliptical_orbit_test_2.json");
     std::array<double,6> initial_orbit_elements=test_satellite.get_orbital_elements();
@@ -57,7 +57,7 @@ TEST(CircularOrbitTests,ConstantEvolvedOrbitalElementsTest){
     }
 }
 
-TEST(CircularOrbitTests,BasicOrbitalElementsTest){
+TEST(EllipticalOrbitTests,BasicOrbitalElementsTest){
 
     Satellite test_satellite("../tests/elliptical_orbit_test_2.json");
     std::array<double,6> initial_orbit_elements=test_satellite.get_orbital_elements();


### PR DESCRIPTION
# Context
I wanted to be able to calculate orbital elements from position and velocity (I was previously only doing the other way around). This is important to orbit verification and properly updating orbital elements during time evolution, especially when thrust profiles are involved so elements other than the true anomaly might be changing with time.

# Changes
- Added workflow (based on approach in Fundamentals of Astrodynamics) to compute orbital elements from position and velocity vectors
- Added orbital element updating to time evolution workflow
- For circular (or approximately circular) orbits: setting arg of periapsis to 0 and calculating true anomaly via argument of latitude
- Added some circular and elliptical orbit unit tests for orbital element calculations

# Integration Testing

Needs to pass existing and new unit tests