### PR TITLE
Adding ability to (optionally) account for J2 perturbation, adding support for plotting individual orbital elements over time

### DIFF
--- a/include/Satellite.h
+++ b/include/Satellite.h
@@ -202,11 +202,12 @@ class Satellite
 
         // std::array<double,3> convert_body_frame_to_ECI(std::array<double,3> input_body_frame_vec);
 
-        void update_orbital_elements_from_position_and_velocity();
+        int update_orbital_elements_from_position_and_velocity();
         std::array<double,6> get_orbital_elements();
 
-        double evolve_RK45(double input_epsilon,double input_initial_timestep);
+        std::pair<double,int> evolve_RK45(double input_epsilon,double input_initial_timestep,bool perturbation=true);
 
+        double get_orbital_element(std::string orbital_element_name);
 };
 
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -11,6 +11,7 @@ using Eigen::MatrixXd;
 
 
 std::array<double,3> calculate_orbital_acceleration(const std::array<double,3> input_r_vec,const double input_spacecraft_mass,std::vector<std::array<double,3>> input_vec_of_force_vectors_in_ECI={});
+std::array<double,3> calculate_orbital_acceleration(const std::array<double,3> input_r_vec,const double input_spacecraft_mass,std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,double input_evaluation_time,const std::array<double,3> input_velocity_vec, double input_inclination,double input_arg_of_periapsis,double input_true_anomaly, bool perturbation);
 
 
 std::array<double,6> RK4_deriv_function_orbit_position_and_velocity(std::array<double,6> input_position_and_velocity,const double input_spacecraft_mass,std::vector<std::array<double,3>> input_vec_of_force_vectors_in_ECI={});
@@ -67,7 +68,7 @@ void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,do
 
 
 
-template <int T> std::pair<std::array<double, T>,std::pair<double,double>> RK45_step(std::array<double, T> y_n, double input_step_size,std::function<std::array<double,T>(const std::array<double,T>,const double,std::vector<ThrustProfileLVLH>, double)> input_derivative_function,const double input_spacecraft_mass,std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,double input_t_n,double input_epsilon){
+template <int T> std::pair<std::array<double, T>,std::pair<double,double>> RK45_step(std::array<double, T> y_n, double input_step_size,std::function<std::array<double,T>(const std::array<double,T>,const double,std::vector<ThrustProfileLVLH>, double,double,double,double,bool)> input_derivative_function,const double input_spacecraft_mass,std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,double input_t_n,double input_epsilon,double input_inclination, double input_arg_of_periapsis, double input_true_anomaly,bool perturbation){
     
     //Implementing RK4(5) method for its adaptive step size
     //Refs:https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta%E2%80%93Fehlberg_method , https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta_methods#The_Runge%E2%80%93Kutta_method
@@ -107,7 +108,7 @@ template <int T> std::pair<std::array<double, T>,std::pair<double,double>> RK45_
                 y_n_evaluated_value.at(y_val_ind) += input_step_size*RK_matrix(k_ind,s_ind)*k_vec_vec.at(s_ind).at(y_val_ind);
             }
         }
-        std::array<double,6> derivative_function_output=input_derivative_function(y_n_evaluated_value,input_spacecraft_mass,input_list_of_thrust_profiles_LVLH,evaluation_time);
+        std::array<double,6> derivative_function_output=input_derivative_function(y_n_evaluated_value,input_spacecraft_mass,input_list_of_thrust_profiles_LVLH,evaluation_time,input_inclination, input_arg_of_periapsis, input_true_anomaly,perturbation);
         for (size_t y_val_ind=0;y_val_ind<y_n.size();y_val_ind++){
             k_vec_at_this_s.at(y_val_ind)=input_step_size*derivative_function_output.at(y_val_ind);
         }
@@ -153,7 +154,7 @@ template <int T> std::pair<std::array<double, T>,std::pair<double,double>> RK45_
         return output_pair;
     }
     else {
-        return RK45_step<6>(y_n, h_new,input_derivative_function,input_spacecraft_mass,input_list_of_thrust_profiles_LVLH, input_t_n, input_epsilon);
+        return RK45_step<6>(y_n, h_new,input_derivative_function,input_spacecraft_mass,input_list_of_thrust_profiles_LVLH, input_t_n, input_epsilon,input_inclination, input_arg_of_periapsis, input_true_anomaly,perturbation);
     }
 
 
@@ -161,7 +162,9 @@ template <int T> std::pair<std::array<double, T>,std::pair<double,double>> RK45_
 
 std::array<double,3> convert_LVLH_to_ECI_manual(std::array<double,3> input_LVLH_vec,std::array<double,3> input_position_vec,std::array<double,3> input_velocity_vec);
 std::array<double,3> convert_ECI_to_LVLH_manual(std::array<double,3> input_ECI_vec,std::array<double,3> input_position_vec,std::array<double,3> input_velocity_vec);
-std::array<double,6> RK45_deriv_function_orbit_position_and_velocity(std::array<double,6> input_position_and_velocity,const double input_spacecraft_mass,std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,double input_evaluation_time);
+std::array<double,6> RK45_deriv_function_orbit_position_and_velocity(std::array<double,6> input_position_and_velocity,const double input_spacecraft_mass,std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,double input_evaluation_time,double input_inclination, double input_arg_of_periapsis, double input_true_anomaly,bool perturbation);
 
+std::array<double,3> convert_cylindrical_to_cartesian(double input_r_comp,double input_theta_comp,double input_z_comp, double input_theta);
+void sim_and_plot_orbital_param_gnuplot(std::vector<Satellite> input_satellite_vector,double input_timestep, double input_total_sim_time, double input_epsilon,std::string input_orbital_element_name);
 
 #endif

--- a/input.json
+++ b/input.json
@@ -1,7 +1,7 @@
 {
-    "Inclination": 0,
+    "Inclination": 1.5,
     "RAAN": 1,
-    "Argument of Periapsis": 1,
+    "Argument of Periapsis": 20,
     "Eccentricity": 0.1,
     "Semimajor Axis": 10000,
     "True Anomaly": 0,

--- a/input_2.json
+++ b/input_2.json
@@ -1,7 +1,7 @@
 {
-    "Inclination": 0,
+    "Inclination": 1.5,
     "RAAN": 1,
-    "Argument of Periapsis": 1,
+    "Argument of Periapsis": 20,
     "Eccentricity": 0.1,
     "Semimajor Axis": 10000,
     "True Anomaly": 0,

--- a/input_4.json
+++ b/input_4.json
@@ -1,11 +1,11 @@
 {
-    "Inclination": 45,
+    "Inclination": 1.5,
     "RAAN": 1,
     "Argument of Periapsis": 10,
-    "Eccentricity": 0.3,
+    "Eccentricity": 0.25,
     "Semimajor Axis": 15000,
     "True Anomaly": 90,
     "Mass": 100,
-    "Name" : "Satellite 3",
-    "Plotting Color": "dark-magenta"
+    "Name" : "Satellite 4",
+    "Plotting Color": "dark-goldenrod"
 }

--- a/input_5.json
+++ b/input_5.json
@@ -2,10 +2,10 @@
     "Inclination": 45,
     "RAAN": 1,
     "Argument of Periapsis": 10,
-    "Eccentricity": 0.3,
+    "Eccentricity": 0.25,
     "Semimajor Axis": 15000,
     "True Anomaly": 90,
     "Mass": 100,
-    "Name" : "Satellite 3",
+    "Name" : "Satellite 5",
     "Plotting Color": "dark-magenta"
 }

--- a/input_6.json
+++ b/input_6.json
@@ -1,11 +1,11 @@
 {
-    "Inclination": 45,
+    "Inclination": 1.5,
     "RAAN": 1,
     "Argument of Periapsis": 10,
-    "Eccentricity": 0.3,
+    "Eccentricity": 0.5,
     "Semimajor Axis": 15000,
     "True Anomaly": 90,
     "Mass": 100,
-    "Name" : "Satellite 3",
-    "Plotting Color": "dark-magenta"
+    "Name" : "Satellite 6",
+    "Plotting Color": "forest-green"
 }

--- a/src/simulation_setup.cpp
+++ b/src/simulation_setup.cpp
@@ -22,12 +22,21 @@ int main()
 
     Satellite test_sat_3("../input_3.json");
     
-    std::vector<Satellite> satellite_vector={test_sat_1,test_sat_2,test_sat_3};
+    std::vector<Satellite> satellite_vector_1={test_sat_1, test_sat_2,test_sat_3};
 
     double timestep=2;
     double total_sim_time=25000;
     double epsilon=pow(10,-11);
-    sim_and_draw_orbit_gnuplot(satellite_vector,timestep,total_sim_time,epsilon);
+    sim_and_draw_orbit_gnuplot(satellite_vector_1,timestep,total_sim_time,epsilon);
 
+    //Now some demonstrations of plotting orbital parameters
+    Satellite test_sat_4("../input_4.json");
+    Satellite test_sat_5("../input_5.json");
+    Satellite test_sat_6("../input_6.json");
+
+
+    std::vector<Satellite> satellite_vector_2={test_sat_4,test_sat_5,test_sat_6};
+    total_sim_time=50000;
+    sim_and_plot_orbital_param_gnuplot(satellite_vector_2,timestep,total_sim_time,epsilon,"Argument of Periapsis");
     return 0;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -128,6 +128,7 @@ std::array<double,3> convert_cylindrical_to_cartesian(double input_r_comp,double
     std::array<double,3> output_cartesian_vec={0,0,0};
 
     //Dot product method
+    //See https://en.wikipedia.org/wiki/Vector_fields_in_cylindrical_and_spherical_coordinates for relation between unit vectors
     double x_comp=input_r_comp*cos(input_theta) + input_theta_comp*(-sin(input_theta));
     double y_comp=input_r_comp*sin(input_theta) + input_theta_comp*(cos(input_theta));
     double z_comp=input_z_comp;

--- a/tests/circular_orbit_test_1_input.json
+++ b/tests/circular_orbit_test_1_input.json
@@ -1,5 +1,5 @@
 {
-    "Inclination": 0,
+    "Inclination": 0.5,
     "RAAN": 0,
     "Argument of Periapsis": 0,
     "Eccentricity": 0,

--- a/tests/circular_orbit_tests.cpp
+++ b/tests/circular_orbit_tests.cpp
@@ -39,7 +39,10 @@ TEST(CircularOrbitTests,TotalEnergyTimestep1){
     Satellite test_satellite("../tests/circular_orbit_test_2_input.json");
     double initial_energy=test_satellite.get_total_energy();
     double test_timestep=1; //s
-    double next_timestep=test_satellite.evolve_RK45(epsilon,test_timestep);
+    bool perturbation_bool=false;
+    std::pair<double,int> new_timestep_and_error_code =test_satellite.evolve_RK45(epsilon,test_timestep,perturbation_bool);
+    double next_timestep=new_timestep_and_error_code.first;
+    int error_code=new_timestep_and_error_code.second;
     double evolved_energy=test_satellite.get_total_energy();
 
     EXPECT_TRUE(abs(initial_energy-evolved_energy)<energy_cons_tolerance) << "Total energy not preserved within tolerance. Difference: " << initial_energy-evolved_energy << "\n";
@@ -50,7 +53,11 @@ TEST(CircularOrbitTests,EvolvedOrbitalRadius1){
     Satellite test_satellite("../tests/circular_orbit_test_2_input.json");
     double calculated_initial_radius=test_satellite.get_radius();
     double test_timestep=1;
-    double next_timestep=test_satellite.evolve_RK45(epsilon,test_timestep);
+    bool perturbation_bool=false; //While from what I can tell (see, e.g., https://ocw.tudelft.nl/wp-content/uploads/AE2104-Orbital-Mechanics-Slides_8.pdf) there's no major effects on semimajor axis from J2 perturbation, not clear to me that this should be exactly constant with J2 perturbation enabled
+
+    std::pair<double,int> new_timestep_and_error_code=test_satellite.evolve_RK45(epsilon,test_timestep,perturbation_bool);
+    double next_timestep=new_timestep_and_error_code.first;
+    int error_code=new_timestep_and_error_code.second;
     double calculated_evolved_radius=test_satellite.get_radius();
 
     EXPECT_TRUE(abs(calculated_initial_radius-calculated_evolved_radius)<length_tolerance) << "Orbital radius not constant within tolerance. Difference: " << calculated_initial_radius-calculated_evolved_radius << "\n";
@@ -61,7 +68,11 @@ TEST(CircularOrbitTests,EvolvedOrbitalSpeed1){
     Satellite test_satellite("../tests/circular_orbit_test_2_input.json");
     double calculated_initial_speed=test_satellite.get_speed();
     double test_timestep=1;
-    double next_timestep=test_satellite.evolve_RK45(epsilon,test_timestep);
+    bool perturbation_bool=false; //While from what I can tell (see, e.g., https://ocw.tudelft.nl/wp-content/uploads/AE2104-Orbital-Mechanics-Slides_8.pdf) there's no major effects on semimajor axis from J2 perturbation, not clear to me that this should be exactly constant with J2 perturbation enabled
+
+    std::pair<double,int> new_timestep_and_error_code=test_satellite.evolve_RK45(epsilon,test_timestep,perturbation_bool);
+    double next_timestep=new_timestep_and_error_code.first;
+    int error_code=new_timestep_and_error_code.second;
     double calculated_evolved_speed=test_satellite.get_speed();
 
     EXPECT_TRUE(abs(calculated_initial_speed-calculated_evolved_speed)<tolerance) << "Orbital speed not constant within tolerance. Difference: " << calculated_initial_speed-calculated_evolved_speed << "\n";
@@ -97,12 +108,16 @@ TEST(CircularOrbitTests,BasicOrbitalElementsTest){
 }
 
 TEST(CircularOrbitTests,ConstantEvolvedOrbitalElementsTest){
-
+    //The idea behind this test is that after evolving a timestep, orbital elements besides true anomaly should be constant (when J2 perturbation is not taken into account)
     Satellite test_satellite("../tests/circular_orbit_test_2_input.json");
     std::array<double,6> initial_orbit_elements=test_satellite.get_orbital_elements();
 
     double test_timestep=1;
-    double next_timestep=test_satellite.evolve_RK45(epsilon,test_timestep);
+    bool perturbation_bool=false;
+
+    std::pair<double,int> new_timestep_and_error_code=test_satellite.evolve_RK45(epsilon,test_timestep,perturbation_bool);
+    double next_timestep=new_timestep_and_error_code.first;
+    int error_code=new_timestep_and_error_code.second;
     std::array<double,6> evolved_orbit_elements=test_satellite.get_orbital_elements();
 
     std::array<std::string,6> orbital_element_name_array;
@@ -141,7 +156,10 @@ TEST(CircularOrbitTests,Thruster_Eccentricity_Change){
     double current_satellite_time=test_satellite.get_instantaneous_time();
     double sim_end_time=110;
     while (current_satellite_time<sim_end_time){
-        double next_timestep=test_satellite.evolve_RK45(epsilon,test_timestep);
+
+        std::pair<double,int> new_timestep_and_error_code =test_satellite.evolve_RK45(epsilon,test_timestep);
+        double next_timestep=new_timestep_and_error_code.first;
+        int error_code=new_timestep_and_error_code.second;
         test_timestep=next_timestep;
         current_satellite_time=test_satellite.get_instantaneous_time();
     }

--- a/tests/elliptical_orbit_tests.cpp
+++ b/tests/elliptical_orbit_tests.cpp
@@ -18,7 +18,9 @@ TEST(EllipticalOrbitTests,EvolvedOrbitalSpeed1){
     double current_time=test_satellite.get_instantaneous_time();
     double next_timestep=0;
     while (current_time<sim_time){
-        next_timestep=test_satellite.evolve_RK45(epsilon,test_timestep);
+        std::pair<double,int> new_timestep_and_error_code=test_satellite.evolve_RK45(epsilon,test_timestep);
+        next_timestep=new_timestep_and_error_code.first;
+        int error_code=new_timestep_and_error_code.second;
         test_timestep=next_timestep;
         current_time=test_satellite.get_instantaneous_time();
     }
@@ -32,7 +34,9 @@ TEST(EllipticalOrbitTests,EvolvedOrbitalSpeed2){
     Satellite test_satellite("../tests/elliptical_orbit_test_2.json");
     double calculated_initial_speed=test_satellite.get_speed();
     double test_timestep=1; //s
-    double next_timestep=test_satellite.evolve_RK45(epsilon,test_timestep);
+    std::pair<double,int> new_timestep_and_error_code =test_satellite.evolve_RK45(epsilon,test_timestep);
+    double next_timestep=new_timestep_and_error_code.first;
+    int error_code=new_timestep_and_error_code.second;
     double calculated_evolved_speed=test_satellite.get_speed();
 
     EXPECT_TRUE(calculated_initial_speed<calculated_evolved_speed) << "Apogee speed not smaller than calculated evolved speed. Difference: " << calculated_initial_speed-calculated_evolved_speed << "\n";
@@ -40,12 +44,16 @@ TEST(EllipticalOrbitTests,EvolvedOrbitalSpeed2){
 
 
 TEST(EllipticalOrbitTests,ConstantEvolvedOrbitalElementsTest){
+    //The idea behind this test is that after evolving a timestep, orbital elements besides true anomaly should be constant (when J2 perturbation is not taken into account)
 
     Satellite test_satellite("../tests/elliptical_orbit_test_2.json");
     std::array<double,6> initial_orbit_elements=test_satellite.get_orbital_elements();
 
     double test_timestep=1; //s
-    double next_timestep=test_satellite.evolve_RK45(epsilon,test_timestep);
+    bool perturbation_bool=false;
+    std::pair<double,int> new_timestep_and_error_code =test_satellite.evolve_RK45(epsilon,test_timestep,perturbation_bool);
+    double next_timestep=new_timestep_and_error_code.first;
+    int error_code=new_timestep_and_error_code.second;
     std::array<double,6> evolved_orbit_elements=test_satellite.get_orbital_elements();
 
     std::array<std::string,6> orbital_element_name_array;


### PR DESCRIPTION
# Context
So far I've been assuming a perfectly spherical Earth in how I calculate the acceleration of each satellite. I wanted to start accounting for effects from the Earth's deviation from a perfect sphere, and I'm starting with accounting for the J2 perturbation. Specifically, I'm including acceleration components from this perturbation in computing the acceleration of the satellite at a given time. I also wanted to be able to plot orbital elements over time to, e.g., be able to see effects of J2 perturbation.

# Changes
- Added computation of acceleration due to J2 perturbation and added to core acceleration calculation (though made it optional to account for this perturbation)
- Added conversion for vectors from cylindrical to cartesian coordinates (as part of above change)
- Added more to demonstration simulation_setup file (and associated new input files) to demonstrate orbital element plotting

# Integration Testing
Needs to pass existing unit tests (some of which have been modified to account for updated workflow)
