### PR TITLE
First pull request adding spacecraft attitude functionality

### DIFF
--- a/include/Satellite.h
+++ b/include/Satellite.h
@@ -193,16 +193,19 @@ class Satellite
             initialize_body_angular_velocity_vec_wrt_LVLH_in_body_frame();
             //making initial omega_x an optional parameter
             if (input_data.find("Initial omega_x")!=input_data.end()){
-                body_angular_velocity_vec_wrt_LVLH_in_body_frame_.at(0)+=input_data.at("Initial omega_x");
+                double initial_omega_x_wrt_LVLH_in_body_frame=input_data.at("Initial omega_x");
+                body_angular_velocity_vec_wrt_LVLH_in_body_frame_.at(0)+=initial_omega_x_wrt_LVLH_in_body_frame;
             }
             //making initial omega_y an optional parameter
             if (input_data.find("Initial omega_y")!=input_data.end()){
-                body_angular_velocity_vec_wrt_LVLH_in_body_frame_.at(1)+=input_data.at("Initial omega_y");
+                double initial_omega_y_wrt_LVLH_in_body_frame=input_data.at("Initial omega_y");
+                body_angular_velocity_vec_wrt_LVLH_in_body_frame_.at(1)+=initial_omega_y_wrt_LVLH_in_body_frame;
             }
 
             //making initial omega_z an optional parameter
             if (input_data.find("Initial omega_z")!=input_data.end()){
-                body_angular_velocity_vec_wrt_LVLH_in_body_frame_.at(2)+=input_data.at("Initial omega_z");
+                double initial_omega_z_wrt_LVLH_in_body_frame=input_data.at("Initial omega_z");
+                body_angular_velocity_vec_wrt_LVLH_in_body_frame_.at(2)+=initial_omega_z_wrt_LVLH_in_body_frame;
             }
 
             orbital_angular_acceleration_=calculate_instantaneous_orbit_angular_acceleration();

--- a/include/Satellite.h
+++ b/include/Satellite.h
@@ -5,6 +5,8 @@
 #include <fstream>
 #include <nlohmann/json.hpp>
 #include <stdexcept>
+
+
 using json=nlohmann::json;
 
 //Define constants
@@ -33,6 +35,27 @@ class ThrustProfileLVLH
         }
 };
 
+class BodyframeTorqueProfile
+{
+    
+    public:
+        double t_start_={0};
+        double t_end_={0};
+        std::array<double,3> bodyframe_torque_list={0,0,0};
+        BodyframeTorqueProfile(double t_start, double t_end, std::array<double,3> bodyframe_torque_vec){
+            t_start_=t_start;
+            t_end_=t_end;
+            bodyframe_torque_list=bodyframe_torque_vec;
+        }
+        BodyframeTorqueProfile(double t_start, double t_end, std::array<double,3> bodyframe_normalized_torque_axis_vec,double input_torque_magnitude){
+            t_start_=t_start;
+            t_end_=t_end;
+            for (size_t ind=0;ind<3;ind++){
+                bodyframe_torque_list.at(ind)=input_torque_magnitude*bodyframe_normalized_torque_axis_vec.at(ind);
+            }
+        }
+};
+
 class Satellite
 {
     private:
@@ -47,15 +70,24 @@ class Satellite
         // double I_={1}; //moment of inertia, taken to be same for all 3 principal axes, set to default value for same reasons as mass
         double t_={0};
 
+        double orbital_rate_={0};
+        double orbital_angular_acceleration_={0}; //Time derivative of orbital rate
 
         //Now body-frame attributes
-        // double pitch_angle_={0};
-        // double roll_angle_={0};
-        // double yaw_angle_={0};
+        //Assuming diagonal J matrix
+        double J_11_={1};
+        double J_22_={1};
+        double J_33_={1};
+        //The following angles are angles of the satellite body frame with respect to the LVLH frame, represented in the body frame
+        double pitch_angle_={0};
+        double roll_angle_={0};
+        double yaw_angle_={0};
 
-        // double theta_={0};
-        // double phi_={0};
-        // double psi_={0};
+        //body-frame angular velocities relative to the LVLH frame, represented in the body frame
+        std::array<double,3> body_angular_velocity_vec_wrt_LVLH_in_body_frame_={0,0,0};
+
+        //quaternion representing attitude of satellite body frame with respect to the LVLH frame
+        std::array<double,4> quaternion_satellite_bodyframe_wrt_LVLH_;
 
         std::string name_="";
 
@@ -66,13 +98,16 @@ class Satellite
         std::array<double,3> ECI_velocity_={0,0,0};
 
         std::vector<ThrustProfileLVLH> thrust_profile_list_={};
+        std::vector<BodyframeTorqueProfile> bodyframe_torque_profile_list_={};
 
         std::vector<std::array<double,3>> list_of_LVLH_forces_at_this_time_={};
         std::vector<std::array<double,3>> list_of_ECI_forces_at_this_time_={};
+        std::vector<std::array<double,3>> list_of_body_frame_torques_at_this_time_={};
         // std::vector<std::array<double,3>> list_of_body_frame_torques_at_this_time_={};
 
         std::pair<double,double> calculate_eccentric_anomaly(const double input_eccentricity, const double input_true_anomaly,const double input_semimajor_axis);
         double calculate_orbital_period(double input_semimajor_axis);
+        void initialize_body_angular_velocity_vec_wrt_LVLH_in_body_frame();
     public:
         std::string plotting_color_="";
         Satellite(std::string input_file_name){
@@ -113,19 +148,27 @@ class Satellite
             true_anomaly_*=(M_PI/180);
 
 
-            // pitch_angle_=input_data.at("Pitch Angle");
-            // //convert to radians
-            // pitch_angle_*=(M_PI/180);
+            //making initial pitch angle an optional parameter
+            if (input_data.find("Initial Pitch Angle")!=input_data.end()){
+                pitch_angle_=input_data.at("Initial Pitch Angle");
+                //convert to radians
+                pitch_angle_*=(M_PI/180);
+            }
+            //making initial roll angle an optional parameter
+            if (input_data.find("Initial Roll Angle")!=input_data.end()){
+                roll_angle_=input_data.at("Initial Roll Angle");
+                //convert to radians
+                roll_angle_*=(M_PI/180);
+            }
+            //making initial yaw angle an optional parameter
+            if (input_data.find("Initial Yaw Angle")!=input_data.end()){
+                yaw_angle_=input_data.at("Initial Yaw Angle");
+                //convert to radians
+                yaw_angle_*=(M_PI/180);
+            }
 
-            // roll_angle_=input_data.at("Roll Angle");
-            // //convert to radians
-            // roll_angle_*=(M_PI/180);
 
-
-            // yaw_angle_=input_data.at("Yaw Angle");
-            // //convert to radians
-            // yaw_angle_*=(M_PI/180);
-
+            initialize_and_normalize_body_quaternion(roll_angle_,pitch_angle_,yaw_angle_);
 
             m_=input_data.at("Mass");
             name_=input_data.at("Name");
@@ -146,6 +189,23 @@ class Satellite
             ECI_position_=convert_perifocal_to_ECI(perifocal_position_);
             ECI_velocity_=convert_perifocal_to_ECI(perifocal_velocity_);
 
+            orbital_rate_=calculate_instantaneous_orbit_rate();
+            initialize_body_angular_velocity_vec_wrt_LVLH_in_body_frame();
+            //making initial omega_x an optional parameter
+            if (input_data.find("Initial omega_x")!=input_data.end()){
+                body_angular_velocity_vec_wrt_LVLH_in_body_frame_.at(0)+=input_data.at("Initial omega_x");
+            }
+            //making initial omega_y an optional parameter
+            if (input_data.find("Initial omega_y")!=input_data.end()){
+                body_angular_velocity_vec_wrt_LVLH_in_body_frame_.at(1)+=input_data.at("Initial omega_y");
+            }
+
+            //making initial omega_z an optional parameter
+            if (input_data.find("Initial omega_z")!=input_data.end()){
+                body_angular_velocity_vec_wrt_LVLH_in_body_frame_.at(2)+=input_data.at("Initial omega_z");
+            }
+
+            orbital_angular_acceleration_=calculate_instantaneous_orbit_angular_acceleration();
 
         }
 
@@ -197,7 +257,8 @@ class Satellite
         void add_LVLH_thrust_profile(std::array<double,3> input_LVLH_normalized_thrust_direction,double input_LVLH_thrust_magnitude,double input_thrust_start_time, double input_thrust_end_time);
         void add_LVLH_thrust_profile(std::array<double,3> input_LVLH_thrust_vector,double input_thrust_start_time, double input_thrust_end_time);
         
-
+        void add_bodyframe_torque_profile(std::array<double,3> input_bodyframe_direction_unit_vec,double input_bodyframe_torque_magnitude,double input_torque_start_time, double input_torque_end_time);
+        void add_bodyframe_torque_profile(std::array<double,3> input_bodyframe_torque_vector,double input_torque_start_time, double input_torque_end_time);
 
         // std::array<double,3> convert_body_frame_to_LVLH(std::array<double,3> input_body_frame_vec);
 
@@ -211,6 +272,10 @@ class Satellite
         std::pair<double,int> evolve_RK45(double input_epsilon,double input_initial_timestep,bool perturbation=true);
 
         double get_orbital_element(std::string orbital_element_name);
+        double calculate_instantaneous_orbit_rate();
+        double calculate_instantaneous_orbit_angular_acceleration();
+        void initialize_and_normalize_body_quaternion(double roll_angle,double pitch_angle,double yaw_angle);
+        double get_attitude_val(std::string input_attitude_val_name);
 };
 
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -8,11 +8,11 @@
 
 using Eigen::Matrix3d;
 using Eigen::MatrixXd;
-
+using Eigen::Vector4d;
+using Eigen::Vector3d;
 
 std::array<double,3> calculate_orbital_acceleration(const std::array<double,3> input_r_vec,const double input_spacecraft_mass,std::vector<std::array<double,3>> input_vec_of_force_vectors_in_ECI={});
 std::array<double,3> calculate_orbital_acceleration(const std::array<double,3> input_r_vec,const double input_spacecraft_mass,std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,double input_evaluation_time,const std::array<double,3> input_velocity_vec, double input_inclination,double input_arg_of_periapsis,double input_true_anomaly, bool perturbation);
-
 
 std::array<double,6> RK4_deriv_function_orbit_position_and_velocity(std::array<double,6> input_position_and_velocity,const double input_spacecraft_mass,std::vector<std::array<double,3>> input_vec_of_force_vectors_in_ECI={});
 
@@ -55,7 +55,7 @@ template <int T> std::array<double, T> RK4_step(std::array<double, T> y_n, doubl
 }
 
 
-void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,double input_timestep, double input_total_sim_time,double input_epsilon);
+void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,double input_timestep, double input_total_sim_time,double input_epsilon, bool perturbation=true);
 
 // Matrix3d z_rot_matrix(double input_angle);
 
@@ -69,12 +69,12 @@ void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,do
 
 
 template <int T> std::pair<std::array<double, T>,std::pair<double,double>> RK45_step(std::array<double, T> y_n, double input_step_size,std::function<std::array<double,T>(const std::array<double,T>,const double,std::vector<ThrustProfileLVLH>, double,double,double,double,bool)> input_derivative_function,const double input_spacecraft_mass,std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,double input_t_n,double input_epsilon,double input_inclination, double input_arg_of_periapsis, double input_true_anomaly,bool perturbation){
-    
+    //Version for satellite orbital motion time evolution
     //Implementing RK4(5) method for its adaptive step size
     //Refs:https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta%E2%80%93Fehlberg_method , https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta_methods#The_Runge%E2%80%93Kutta_method
-    double nodes[6]={0.0,1.0/4,3.0/8,12.0/13,1.0,1.0/2}; //c coefficients
-    double CH_vec[6]={16.0/135,0.0,6656.0/12825,28561.0/56430,-9.0/50,2.0/55}; 
-    double CT_vec[6]={-1.0/360,0.0,128.0/4275,2197.0/75240,-1.0/50,-2.0/55}; 
+    std::array<double,6> nodes={0.0,1.0/4,3.0/8,12.0/13,1.0,1.0/2}; //c coefficients
+    std::array<double,6> CH_vec={16.0/135,0.0,6656.0/12825,28561.0/56430,-9.0/50,2.0/55}; 
+    std::array<double,6> CT_vec={-1.0/360,0.0,128.0/4275,2197.0/75240,-1.0/50,-2.0/55}; 
     int s=6;
 
     MatrixXd RK_matrix=MatrixXd::Zero(s,s);
@@ -93,7 +93,6 @@ template <int T> std::pair<std::array<double, T>,std::pair<double,double>> RK45_
     RK_matrix(5,2)= -3544.0/2565;
     RK_matrix(5,3)= 1859.0/4104;
     RK_matrix(5,4)= -11.0/40;
-
 
 
     std::vector<std::array<double, T>> k_vec_vec={};
@@ -116,7 +115,7 @@ template <int T> std::pair<std::array<double, T>,std::pair<double,double>> RK45_
     }
 
 
-    std::array<double,6> y_nplusone=y_n;
+    std::array<double,T> y_nplusone=y_n;
 
     for (size_t s_ind=0;s_ind<s;s_ind++){
         for (size_t y_ind=0;y_ind<y_n.size();y_ind++){
@@ -125,7 +124,7 @@ template <int T> std::pair<std::array<double, T>,std::pair<double,double>> RK45_
         }
     }
 
-    double TE_vec[6]={0,0,0,0,0,0};
+    std::array<double,T> TE_vec;
     for (size_t s_ind=0;s_ind<s;s_ind++){
 
         for (size_t y_ind=0;y_ind<std::size(TE_vec);y_ind++){
@@ -154,7 +153,7 @@ template <int T> std::pair<std::array<double, T>,std::pair<double,double>> RK45_
         return output_pair;
     }
     else {
-        return RK45_step<6>(y_n, h_new,input_derivative_function,input_spacecraft_mass,input_list_of_thrust_profiles_LVLH, input_t_n, input_epsilon,input_inclination, input_arg_of_periapsis, input_true_anomaly,perturbation);
+        return RK45_step<T>(y_n, h_new,input_derivative_function,input_spacecraft_mass,input_list_of_thrust_profiles_LVLH, input_t_n, input_epsilon,input_inclination, input_arg_of_periapsis, input_true_anomaly,perturbation);
     }
 
 
@@ -165,13 +164,126 @@ std::array<double,3> convert_ECI_to_LVLH_manual(std::array<double,3> input_ECI_v
 std::array<double,6> RK45_deriv_function_orbit_position_and_velocity(std::array<double,6> input_position_and_velocity,const double input_spacecraft_mass,std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,double input_evaluation_time,double input_inclination, double input_arg_of_periapsis, double input_true_anomaly,bool perturbation);
 
 std::array<double,3> convert_cylindrical_to_cartesian(double input_r_comp,double input_theta_comp,double input_z_comp, double input_theta);
-void sim_and_plot_orbital_elem_gnuplot(std::vector<Satellite> input_satellite_vector,double input_timestep, double input_total_sim_time, double input_epsilon,std::string input_orbital_element_name);
+void sim_and_plot_orbital_elem_gnuplot(std::vector<Satellite> input_satellite_vector,double input_timestep, double input_total_sim_time, double input_epsilon,std::string input_orbital_element_name,bool perturbation=true);
+void sim_and_plot_attitude_evolution_gnuplot(std::vector<Satellite> input_satellite_vector,double input_timestep, double input_total_sim_time,double input_epsilon,std::string input_plotted_val_name,bool perturbation=true);
 
 
+Matrix3d rollyawpitch_bodyframe_to_LVLH(std::array<double,3> input_bodyframe_vec, double input_roll, double input_pitch, double input_yaw);
+std::array<double,4> rollyawpitch_angles_to_quaternion(double input_roll, double input_pitch, double input_yaw);
+std::array<double,4> rollpitchyaw_angles_to_quaternion(double input_roll, double input_pitch, double input_yaw);
+
+Matrix3d LVLH_to_body_transformation_matrix_from_quaternion(std::array<double,4> input_bodyframe_quaternion_relative_to_LVLH);
+Vector4d quaternion_multiplication(Vector4d quaternion_1, Vector4d quaternion_2);
+Vector4d quaternion_kinematics_equation(Vector4d quaternion_of_bodyframe_relative_to_ref_frame, Vector3d angular_velocity_vec_wrt_ref_frame_in_body_frame);
+std::array<double,7> RK45_satellite_body_angular_deriv_function( std::array<double,7> combined_bodyframe_angular_array, Matrix3d J_matrix, std::vector<BodyframeTorqueProfile> input_bodyframe_torque_profile_list,  Vector3d input_omega_I,  double input_orbital_angular_acceleration, Matrix3d input_LVLH_to_bodyframe_transformation_matrix, Vector3d input_omega_LVLH_wrt_inertial_in_LVLH, double input_evaluation_time);
+std::array<double,13> RK45_combined_orbit_position_velocity_attitude_deriv_function( std::array<double,13> combined_position_velocity_bodyframe_angular_array,Matrix3d J_matrix, std::vector<BodyframeTorqueProfile> input_bodyframe_torque_profile_list,  Vector3d input_omega_I,  double input_orbital_angular_acceleration, Matrix3d input_LVLH_to_bodyframe_transformation_matrix, Vector3d input_omega_LVLH_wrt_inertial_in_LVLH,const double input_spacecraft_mass,std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,double input_evaluation_time,double input_inclination, double input_arg_of_periapsis, double input_true_anomaly,bool perturbation);
+
+
+template <int T> std::pair<std::array<double, T>,std::pair<double,double>> RK45_step(std::array<double, T> y_n, double input_step_size,std::function<std::array<double,T>( std::array<double,T> , Matrix3d , std::vector<BodyframeTorqueProfile> ,  Vector3d ,  double , Matrix3d , Vector3d,double,std::vector<ThrustProfileLVLH>,double,double,double,double,bool )> input_combined_derivative_function, Matrix3d J_matrix, std::vector<BodyframeTorqueProfile> input_bodyframe_torque_profile_list,  Vector3d input_omega_I,  double input_orbital_angular_acceleration, Matrix3d input_LVLH_to_bodyframe_transformation_matrix, Vector3d input_omega_LVLH_wrt_inertial_in_LVLH, double input_spacecraft_mass,std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,double input_inclination, double input_arg_of_periapsis, double input_true_anomaly,bool perturbation,double input_t_n,double input_epsilon){
+    //Version for combined satellite orbital motion and attitude time evolution
+    //Implementing RK4(5) method for its adaptive step size
+    //Refs:https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta%E2%80%93Fehlberg_method , https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta_methods#The_Runge%E2%80%93Kutta_method
+
+    std::array<double,6> nodes={0.0,1.0/4,3.0/8,12.0/13,1.0,1.0/2}; //c coefficients
+    std::array<double,6> CH_vec={16.0/135,0.0,6656.0/12825,28561.0/56430,-9.0/50,2.0/55}; 
+    std::array<double,6> CT_vec={-1.0/360,0.0,128.0/4275,2197.0/75240,-1.0/50,-2.0/55}; 
+    int s=6;
+
+    MatrixXd RK_matrix=MatrixXd::Zero(s,s);
+    RK_matrix(1,0)=1.0/4;
+    RK_matrix(2,0)=3.0/32;
+    RK_matrix(2,1)=9.0/32;
+    RK_matrix(3,0)=1932.0/2197;
+    RK_matrix(3,1)= -7200.0/2197;
+    RK_matrix(3,2)= 7296.0/2197;
+    RK_matrix(4,0)= 439.0/216;
+    RK_matrix(4,1)= -8.0;
+    RK_matrix(4,2)= 3680.0/513;
+    RK_matrix(4,3)= -845.0/4104;
+    RK_matrix(5,0)= -8.0/27;
+    RK_matrix(5,1)= 2.0;
+    RK_matrix(5,2)= -3544.0/2565;
+    RK_matrix(5,3)= 1859.0/4104;
+    RK_matrix(5,4)= -11.0/40;
+
+
+    std::vector<std::array<double, T>> k_vec_vec={};
+
+    //Need to populate k_vec (compute vector k_i for i=0...s-1)
+    for (size_t k_ind=0;k_ind<s;k_ind++){
+        double evaluation_time=input_t_n+(nodes.at(k_ind)*input_step_size);
+        std::array<double, T> y_n_evaluated_value=y_n;
+        std::array<double, T> k_vec_at_this_s;
+        for (size_t s_ind=0; s_ind<k_ind; s_ind++){
+            for (size_t y_val_ind=0;y_val_ind<y_n.size();y_val_ind++){
+
+                y_n_evaluated_value.at(y_val_ind) += input_step_size*RK_matrix(k_ind,s_ind)*k_vec_vec.at(s_ind).at(y_val_ind);
+            }
+        }
+        std::array<double,T> derivative_function_output=input_combined_derivative_function(y_n_evaluated_value, J_matrix, input_bodyframe_torque_profile_list,  input_omega_I, input_orbital_angular_acceleration, input_LVLH_to_bodyframe_transformation_matrix, input_omega_LVLH_wrt_inertial_in_LVLH, input_spacecraft_mass, input_list_of_thrust_profiles_LVLH, evaluation_time,input_inclination,input_arg_of_periapsis,input_true_anomaly,perturbation);
+        for (size_t y_val_ind=0;y_val_ind<y_n.size();y_val_ind++){
+            k_vec_at_this_s.at(y_val_ind)=input_step_size*derivative_function_output.at(y_val_ind);
+        }
+
+        k_vec_vec.push_back(k_vec_at_this_s);
+    }
+
+
+    std::array<double,T> y_nplusone=y_n;
+
+    for (size_t s_ind=0;s_ind<s;s_ind++){
+        for (size_t y_ind=0;y_ind<y_n.size();y_ind++){
+            double tmp=CH_vec.at(s_ind)*k_vec_vec.at(s_ind).at(y_ind);
+            y_nplusone.at(y_ind)+=tmp;
+        }
+    }
+
+    std::array<double,T> TE_vec ={0};
+    for (size_t y_ind=0;y_ind<y_n.size();y_ind++){
+
+        for (size_t s_ind=0;s_ind<s;s_ind++){
+
+            TE_vec.at(y_ind)+=CT_vec.at(s_ind)*k_vec_vec.at(s_ind).at(y_ind);
+
+        }
+        
+    }
+
+    for (size_t ind=0; ind<TE_vec.size();ind++){
+        TE_vec.at(ind)=abs(TE_vec.at(ind));
+    }
+
+    //I'm going to use the max TE found across the whole position+velocity vec as the TE in the calculation of the next stepsize
+    double max_TE=TE_vec.at( std::distance( std::begin(TE_vec), std::max_element(std::begin(TE_vec),std::end(TE_vec)) ) );
+    double epsilon_ratio=input_epsilon/max_TE;
+
+    double h_new=0.9*input_step_size*std::pow(epsilon_ratio,1.0/5);
+
+    if (max_TE<=input_epsilon){
+        std::pair<double,double> output_timestep_pair;
+        output_timestep_pair.first=input_step_size; //First timestep size in this pair is the one successfully used in this calculation
+        output_timestep_pair.second=h_new; //Second timestep size in this pair is the one to be used in the next step
+        std::pair<std::array<double, T>,std::pair<double,double>> output_pair;
+        output_pair.first=y_nplusone;
+        output_pair.second=output_timestep_pair;
+        return output_pair;
+    }
+    else {
+        return RK45_step<T>(y_n,h_new,input_combined_derivative_function, J_matrix,input_bodyframe_torque_profile_list, input_omega_I, input_orbital_angular_acceleration, input_LVLH_to_bodyframe_transformation_matrix, input_omega_LVLH_wrt_inertial_in_LVLH, input_spacecraft_mass, input_list_of_thrust_profiles_LVLH, input_inclination,  input_arg_of_periapsis,  input_true_anomaly, perturbation, input_t_n, input_epsilon);
+    }
+}
+Vector3d calculate_omega_I(Vector3d input_bodyframe_ang_vel_vector_wrt_lvlh, Matrix3d input_LVLH_to_bodyframe_transformation_matrix,double input_orbital_rate);
+
+Matrix3d construct_J_matrix(double input_Jxx, double input_Jyy, double input_Jzz);
+
+std::array<double,3> convert_quaternion_to_roll_yaw_pitch_angles(std::array<double,4>);
+
+std::array<double,4> normalize_quaternion(std::array<double,4> input_quaternion);
 
 
 
 
 std::array<double,4> bodyframe_quaternion_deriv(std::array<double,4> input_bodyframe_quaternion,double input_w_1, double input_w_2, double input_w_3);
+std::array<double,3> convert_array_from_LVLH_to_bodyframe(std::array<double,3> input_LVLH_frame_array,double input_roll, double input_yaw, double input_pitch);
 
 #endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -99,7 +99,7 @@ template <int T> std::pair<std::array<double, T>,std::pair<double,double>> RK45_
 
     //Need to populate k_vec (compute vector k_i for i=0...s-1)
     for (size_t k_ind=0;k_ind<s;k_ind++){
-        double evaluation_time=input_t_n+(nodes[k_ind]*input_step_size);
+        double evaluation_time=input_t_n+(nodes.at(k_ind)*input_step_size);
         std::array<double, T> y_n_evaluated_value=y_n;
         std::array<double, T> k_vec_at_this_s;
         for (size_t s_ind=0; s_ind<k_ind; s_ind++){
@@ -119,7 +119,7 @@ template <int T> std::pair<std::array<double, T>,std::pair<double,double>> RK45_
 
     for (size_t s_ind=0;s_ind<s;s_ind++){
         for (size_t y_ind=0;y_ind<y_n.size();y_ind++){
-            double tmp=CH_vec[s_ind]*k_vec_vec.at(s_ind).at(y_ind);
+            double tmp=CH_vec.at(s_ind)*k_vec_vec.at(s_ind).at(y_ind);
             y_nplusone.at(y_ind)+=tmp;
         }
     }
@@ -129,16 +129,16 @@ template <int T> std::pair<std::array<double, T>,std::pair<double,double>> RK45_
 
         for (size_t y_ind=0;y_ind<std::size(TE_vec);y_ind++){
 
-            TE_vec[y_ind]+=CT_vec[s_ind]*k_vec_vec.at(s_ind).at(y_ind);
+            TE_vec.at(y_ind)+=CT_vec.at(s_ind)*k_vec_vec.at(s_ind).at(y_ind);
 
         }
     }
 
     for (size_t y_ind=0; y_ind<std::size(TE_vec);y_ind++){
-        TE_vec[y_ind]=abs(TE_vec[y_ind]);
+        TE_vec.at(y_ind)=abs(TE_vec.at(y_ind));
     }
     //I'm going to use the max TE found across the whole position+velocity vec as the TE in the calculation of the next stepsize
-    double max_TE=TE_vec[ std::distance( std::begin(TE_vec), std::max_element(std::begin(TE_vec),std::end(TE_vec)) ) ];
+    double max_TE=TE_vec.at( std::distance( std::begin(TE_vec), std::max_element(std::begin(TE_vec),std::end(TE_vec)) ) );
     double epsilon_ratio=input_epsilon/max_TE;
 
     double h_new=0.9*input_step_size*std::pow(epsilon_ratio,1.0/5);
@@ -162,6 +162,8 @@ template <int T> std::pair<std::array<double, T>,std::pair<double,double>> RK45_
 std::array<double,3> convert_LVLH_to_ECI_manual(std::array<double,3> input_LVLH_vec,std::array<double,3> input_position_vec,std::array<double,3> input_velocity_vec);
 std::array<double,3> convert_ECI_to_LVLH_manual(std::array<double,3> input_ECI_vec,std::array<double,3> input_position_vec,std::array<double,3> input_velocity_vec);
 std::array<double,6> RK45_deriv_function_orbit_position_and_velocity(std::array<double,6> input_position_and_velocity,const double input_spacecraft_mass,std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,double input_evaluation_time);
+
+std::array<double,4> bodyframe_quaternion_deriv(std::array<double,4> input_bodyframe_quaternion,double input_w_1, double input_w_2, double input_w_3);
 
 
 #endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -163,7 +163,12 @@ std::array<double,3> convert_LVLH_to_ECI_manual(std::array<double,3> input_LVLH_
 std::array<double,3> convert_ECI_to_LVLH_manual(std::array<double,3> input_ECI_vec,std::array<double,3> input_position_vec,std::array<double,3> input_velocity_vec);
 std::array<double,6> RK45_deriv_function_orbit_position_and_velocity(std::array<double,6> input_position_and_velocity,const double input_spacecraft_mass,std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,double input_evaluation_time);
 
-std::array<double,4> bodyframe_quaternion_deriv(std::array<double,4> input_bodyframe_quaternion,double input_w_1, double input_w_2, double input_w_3);
 
+
+
+
+
+
+std::array<double,4> bodyframe_quaternion_deriv(std::array<double,4> input_bodyframe_quaternion,double input_w_1, double input_w_2, double input_w_3);
 
 #endif

--- a/input_7.json
+++ b/input_7.json
@@ -7,6 +7,8 @@
     "True Anomaly": 0,
     "Mass": 100,
     "Name" : "Satellite 7",
-    "Plotting Color" : "dark-goldenrod"
+    "Plotting Color" : "dark-goldenrod",
+    "Initial Roll Angle": 0,
+    "Initial omega_y": 0
 
 }

--- a/input_7.json
+++ b/input_7.json
@@ -1,0 +1,12 @@
+{
+    "Inclination": 1.5,
+    "RAAN": 1,
+    "Argument of Periapsis": 20,
+    "Eccentricity": 0.1,
+    "Semimajor Axis": 10000,
+    "True Anomaly": 0,
+    "Mass": 100,
+    "Name" : "Satellite 7",
+    "Plotting Color" : "dark-goldenrod"
+
+}

--- a/src/Satellite.cpp
+++ b/src/Satellite.cpp
@@ -71,8 +71,8 @@ std::array<double,3> Satellite::calculate_perifocal_velocity(){
 
 
 std::array<double,3> Satellite::convert_perifocal_to_ECI(std::array<double,3> input_perifocal_vec){
-    //method from Fundamentals of Astrodynamics
-    //sounds like what they describe as their "Geocentric-Equatorial" coordinate system is ECI
+    //Method from Fundamentals of Astrodynamics
+    //Sounds like what they describe as their "Geocentric-Equatorial" coordinate system is ECI
     Matrix3d R_tilde_matrix;
 
     R_tilde_matrix(0,0)=cos(raan_)*cos(arg_of_periapsis_)-sin(raan_)*sin(arg_of_periapsis_)*cos(inclination_);
@@ -112,8 +112,8 @@ std::array<double,3> Satellite::convert_perifocal_to_ECI(std::array<double,3> in
 
 
 std::array<double,3> Satellite::convert_ECI_to_perifocal(std::array<double,3> input_ECI_vec){
-    //method from Fundamentals of Astrodynamics, and using https://en.wikipedia.org/wiki/Perifocal_coordinate_system
-    //sounds like what they describe as their "Geocentric-Equatorial" coordinate system is ECI
+    //Method from Fundamentals of Astrodynamics, and using https://en.wikipedia.org/wiki/Perifocal_coordinate_system
+    //Sounds like what they describe as their "Geocentric-Equatorial" coordinate system is ECI
     Matrix3d R_tilde_matrix;
 
     R_tilde_matrix(0,0)=cos(raan_)*cos(arg_of_periapsis_)-sin(raan_)*sin(arg_of_periapsis_)*cos(inclination_);
@@ -392,39 +392,78 @@ std::array<double,6> Satellite::get_orbital_elements(){
 std::pair<double,int> Satellite::evolve_RK45(double input_epsilon,double input_step_size,bool perturbation){
     //perturbation is a flag which, when set to true, currently accounts for J2 perturbation.
 
-    //Format input position and velocity arrays into single array for RK4(5) step
-    std::array<double,6> combined_initial_position_and_velocity_array={};
+    //Let's do a single RK45_step call with y_n combined between orbital motion and attitude variables,
+    // y_n = {ECI_position_x, ECI_position_y, ECI_position_z, ECI_velocity_x, ECI_velocity_y, ECI_velocity_z, q_0, q_1, q_2, q_3, omega_x, omega_y, omega_z}
+    // Where the quaternion represents the attitude of the spacecraft body frame with respect to the LVLH frame, and omega_i is the angular velocity around the ith axis of the body frame with respect to the LVLH frame, represented in the body frame
+    std::array<double,13> combined_initial_position_velocity_quaternion_angular_velocity_array={};
     std::pair<std::array<double,3>,std::array<double,3>> output_position_velocity_pair={};
 
     for (size_t ind=0;ind<3;ind++){
-        combined_initial_position_and_velocity_array.at(ind) = ECI_position_.at(ind);
+        combined_initial_position_velocity_quaternion_angular_velocity_array.at(ind) = ECI_position_.at(ind);
     }
     for (size_t ind=3;ind<6;ind++){
-        combined_initial_position_and_velocity_array.at(ind) = ECI_velocity_.at(ind-3);
+        combined_initial_position_velocity_quaternion_angular_velocity_array.at(ind) = ECI_velocity_.at(ind-3);
+    }
+    for (size_t ind=6;ind<10;ind++){
+        combined_initial_position_velocity_quaternion_angular_velocity_array.at(ind) = quaternion_satellite_bodyframe_wrt_LVLH_.at(ind-6);
     }
 
+    for (size_t ind=10;ind<13;ind++){
+        combined_initial_position_velocity_quaternion_angular_velocity_array.at(ind) = body_angular_velocity_vec_wrt_LVLH_in_body_frame_.at(ind-10);
+    }
     
 
-    std::pair<std::array<double, 6>,std::pair<double,double>> output_pair= RK45_step<6>(combined_initial_position_and_velocity_array,input_step_size,RK45_deriv_function_orbit_position_and_velocity,m_,thrust_profile_list_,t_,input_epsilon,inclination_, arg_of_periapsis_, true_anomaly_,perturbation);
-    std::array<double, 6> output_combined_position_and_velocity_array=output_pair.first;
+    Matrix3d LVLH_to_body_transformation_matrix= LVLH_to_body_transformation_matrix_from_quaternion(quaternion_satellite_bodyframe_wrt_LVLH_);
+
+
+    Vector3d body_angular_velocity_vec_wrt_LVLH_in_body_frame_eigenform={body_angular_velocity_vec_wrt_LVLH_in_body_frame_.at(0),body_angular_velocity_vec_wrt_LVLH_in_body_frame_.at(1),body_angular_velocity_vec_wrt_LVLH_in_body_frame_.at(2)};
+
+    Vector3d omega_I=calculate_omega_I(body_angular_velocity_vec_wrt_LVLH_in_body_frame_eigenform,LVLH_to_body_transformation_matrix,orbital_rate_);
+
+
+    Vector3d omega_LVLH_wrt_inertial_in_LVLH={0,-orbital_rate_,0};
+
+    Matrix3d J_matrix= construct_J_matrix(J_11_, J_22_, J_33_);
+
+
+
+    std::pair<std::array<double, 13>,std::pair<double,double>> output_pair=RK45_step<13>(combined_initial_position_velocity_quaternion_angular_velocity_array, input_step_size,RK45_combined_orbit_position_velocity_attitude_deriv_function, J_matrix,bodyframe_torque_profile_list_, omega_I, orbital_angular_acceleration_, LVLH_to_body_transformation_matrix, omega_LVLH_wrt_inertial_in_LVLH,m_,thrust_profile_list_,  inclination_,  arg_of_periapsis_,  true_anomaly_, perturbation,t_, input_epsilon);
+
+    std::array<double, 13> output_combined_position_velocity_quaternion_angular_velocity_array=output_pair.first;
     double step_size_successfully_used_here=output_pair.second.first;
     double new_step_size=output_pair.second.second;
 
-    // std::array<double,6> output_combined_angular_array= RK4_step<6>(combined_initial_angular_array,input_step_size,RK4_deriv_function_angular,I_,list_of_body_frame_torques_at_this_time_,list_of_body_frame_torques_at_half_timestep_past,list_of_body_frame_torques_at_one_timestep_past);
 
     
     for (size_t ind=0;ind<3;ind++){
-        ECI_position_.at(ind) = output_combined_position_and_velocity_array.at(ind);
-        ECI_velocity_.at(ind) = output_combined_position_and_velocity_array.at(ind+3);
+        ECI_position_.at(ind) = output_combined_position_velocity_quaternion_angular_velocity_array.at(ind);
+        ECI_velocity_.at(ind) = output_combined_position_velocity_quaternion_angular_velocity_array.at(ind+3);
         //Also update the perifocal versions
         perifocal_position_=convert_ECI_to_perifocal(ECI_position_);
         perifocal_velocity_=convert_ECI_to_perifocal(ECI_velocity_);
     }
     t_+=step_size_successfully_used_here;
 
+    for (size_t ind=0;ind<quaternion_satellite_bodyframe_wrt_LVLH_.size();ind++){
+        quaternion_satellite_bodyframe_wrt_LVLH_.at(ind)=output_combined_position_velocity_quaternion_angular_velocity_array.at(ind+6);
+    }
+    quaternion_satellite_bodyframe_wrt_LVLH_=normalize_quaternion(quaternion_satellite_bodyframe_wrt_LVLH_);
+    std::array<double,3> updated_roll_yaw_pitch= convert_quaternion_to_roll_yaw_pitch_angles(quaternion_satellite_bodyframe_wrt_LVLH_);
+    
+    roll_angle_=updated_roll_yaw_pitch.at(0);
+    yaw_angle_=updated_roll_yaw_pitch.at(1);
+    pitch_angle_=updated_roll_yaw_pitch.at(2);
+
+    for (size_t ind=0;ind<body_angular_velocity_vec_wrt_LVLH_in_body_frame_.size();ind++){
+        body_angular_velocity_vec_wrt_LVLH_in_body_frame_.at(ind)=output_combined_position_velocity_quaternion_angular_velocity_array.at(ind+10);
+    }
+
+
 
     //Update orbital parameters
     int orbit_elems_error_code = update_orbital_elements_from_position_and_velocity();
+    orbital_rate_=calculate_instantaneous_orbit_rate();
+    orbital_angular_acceleration_=calculate_instantaneous_orbit_angular_acceleration();
     std::pair<double,int> evolve_RK45_output_pair;
     
     evolve_RK45_output_pair.first=new_step_size;
@@ -453,8 +492,118 @@ double Satellite::get_orbital_element(std::string orbital_element_name){
     else if (orbital_element_name=="True Anomaly"){
         return true_anomaly_;
     }
+    else if (orbital_element_name=="Orbital Rate"){
+        return orbital_rate_;
+    }
+    else if (orbital_element_name=="Orbital Angular Acceleration"){
+        return orbital_angular_acceleration_;
+    }
     else {
         std::cout << "Unrecognized argument, returning -1";
         return -1;
     }
+}
+
+void Satellite::add_bodyframe_torque_profile(std::array<double,3> input_bodyframe_torque_vector,double input_torque_start_time, double input_torque_end_time){
+    BodyframeTorqueProfile new_torque_profile(input_torque_start_time, input_torque_end_time, input_bodyframe_torque_vector);
+    bodyframe_torque_profile_list_.push_back(new_torque_profile);
+    if (input_torque_start_time==0){
+        list_of_body_frame_torques_at_this_time_.push_back(input_bodyframe_torque_vector);
+    }
+}
+
+void Satellite::add_bodyframe_torque_profile(std::array<double,3> input_bodyframe_direction_unit_vec,double input_bodyframe_torque_magnitude,double input_torque_start_time, double input_torque_end_time){
+    std::array<double,3> input_bodyframe_torque_vector={0,0,0};
+
+    for (size_t ind=0;ind<3;ind++){
+        input_bodyframe_torque_vector.at(ind)=input_bodyframe_torque_magnitude*input_bodyframe_direction_unit_vec.at(ind);
+    }    
+    BodyframeTorqueProfile new_torque_profile(input_torque_start_time, input_torque_end_time, input_bodyframe_torque_vector);
+    bodyframe_torque_profile_list_.push_back(new_torque_profile);
+    if (input_torque_start_time==0){
+        list_of_body_frame_torques_at_this_time_.push_back(input_bodyframe_torque_vector);
+    }
+}
+
+
+double Satellite::calculate_instantaneous_orbit_rate(){
+    //Need to figure out how to calculate the equivalent of w_0 in section 4.3.1 of https://ntrs.nasa.gov/api/citations/20240009554/downloads/Space%20Attitude%20Development%20Control.pdf but for general elliptical orbits
+    //Is this proportional to the rate of change of the true anomaly? 
+    //Proof sketched out here: https://space.stackexchange.com/questions/21615/how-to-calculate-the-complete-true-anomaly-motion-in-an-elliptical-orbit
+    Vector3d position_vector={perifocal_position_.at(0),perifocal_position_.at(1),perifocal_position_.at(2)};
+    Vector3d velocity_vector={perifocal_velocity_.at(0),perifocal_velocity_.at(1),perifocal_velocity_.at(2)};
+    Vector3d h_vector=position_vector.cross(velocity_vector);
+    double h=h_vector.norm();
+    double r=get_radius();
+    double orbit_rate=h/(r*r);
+    return orbit_rate;
+}
+
+double Satellite::calculate_instantaneous_orbit_angular_acceleration(){
+    //Need to figure out how to calculate the equivalent of w_0^dot to get the w_lvlh^dot term in Ch.4 of https://ntrs.nasa.gov/api/citations/20240009554/downloads/Space%20Attitude%20Development%20Control.pdf but for general elliptical orbits
+    //Proof sketched out here: https://space.stackexchange.com/questions/21615/how-to-calculate-the-complete-true-anomaly-motion-in-an-elliptical-orbit
+    //This assumes angular momentum is constant
+    Vector3d position_vector={perifocal_position_.at(0),perifocal_position_.at(1),perifocal_position_.at(2)};
+    Vector3d velocity_vector={perifocal_velocity_.at(0),perifocal_velocity_.at(1),perifocal_velocity_.at(2)};
+    Vector3d h_vector=position_vector.cross(velocity_vector);
+    double h=h_vector.norm();
+    double r=get_radius();
+    Vector3d unit_position_vector=position_vector;
+    unit_position_vector.normalize();
+    double orbit_angular_acceleration=-2*h/(r*r*r)*velocity_vector.dot(unit_position_vector);
+
+    //Neglecting term relating to derivative of h for now (would be an h^dot / r^2 term added to the above term)
+    return orbit_angular_acceleration;
+}
+
+
+void Satellite::initialize_and_normalize_body_quaternion(double roll_angle,double pitch_angle,double yaw_angle){
+    std::array<double,4> quaternion= rollyawpitch_angles_to_quaternion(roll_angle,pitch_angle,yaw_angle);
+    std::array<double,4>  normalized_quaternion=normalize_quaternion(quaternion);
+    quaternion_satellite_bodyframe_wrt_LVLH_=normalized_quaternion;
+    return;
+}
+
+double Satellite::get_attitude_val(std::string input_attitude_val_name){
+    if (input_attitude_val_name=="Roll"){
+        return roll_angle_;
+    }
+    else if (input_attitude_val_name=="Pitch"){
+        return pitch_angle_;
+    }
+    else if (input_attitude_val_name=="Yaw"){
+        return yaw_angle_;
+    }
+    else if (input_attitude_val_name=="omega_x"){
+        return body_angular_velocity_vec_wrt_LVLH_in_body_frame_.at(0);
+    }
+    else if (input_attitude_val_name=="omega_y"){
+        return body_angular_velocity_vec_wrt_LVLH_in_body_frame_.at(1);
+    }
+    else if (input_attitude_val_name=="omega_z"){
+        return body_angular_velocity_vec_wrt_LVLH_in_body_frame_.at(2);
+    }
+    else if (input_attitude_val_name=="q_0"){
+        return quaternion_satellite_bodyframe_wrt_LVLH_.at(0);
+    }
+    else if (input_attitude_val_name=="q_1"){
+        return quaternion_satellite_bodyframe_wrt_LVLH_.at(1);
+    }
+    else if (input_attitude_val_name=="q_2"){
+        return quaternion_satellite_bodyframe_wrt_LVLH_.at(2);
+    }
+    else if (input_attitude_val_name=="q_3"){
+        return quaternion_satellite_bodyframe_wrt_LVLH_.at(3);
+    }
+    else {
+        std::cout << "Invalid attitude val choice " << input_attitude_val_name<< ", returning -1\n";
+        return -1.0;
+    }
+}
+
+
+
+void Satellite::initialize_body_angular_velocity_vec_wrt_LVLH_in_body_frame(){
+    std::array<double,3> initial_body_angular_velocity_in_LVLH_frame={0,orbital_rate_,0};
+    body_angular_velocity_vec_wrt_LVLH_in_body_frame_=convert_array_from_LVLH_to_bodyframe( initial_body_angular_velocity_in_LVLH_frame,roll_angle_, yaw_angle_,  pitch_angle_); //Because LVLH is always rotating around y axis to keep z pointed towards Earth
 }

--- a/src/Satellite.cpp
+++ b/src/Satellite.cpp
@@ -339,6 +339,7 @@ int Satellite::update_orbital_elements_from_position_and_velocity(){
             calculated_arg_of_periapsis=2*M_PI-calculated_arg_of_periapsis;
         }
 
+
         calculated_true_anomaly=acos(e_vec.dot(position_vector)/(calculated_eccentricity*r_magnitude));
         if (position_vector.dot(velocity_vector)<0){
             calculated_true_anomaly=2*M_PI-calculated_true_anomaly;
@@ -356,6 +357,10 @@ int Satellite::update_orbital_elements_from_position_and_velocity(){
         calculated_arg_of_periapsis=0; //Setting this
 
         double calculated_arg_of_latitude=acos(n_vector.dot(position_vector)/(n*r_magnitude));
+        if (std::isnan(calculated_arg_of_latitude)){
+            std:: cout << "Calculated argument of latitude was undefined. One possible cause of this is an orbit with zero inclination. Current magnitude of line of nodes: " << n << "\n";
+            error_code=1;
+        }
         if (position_vector(2)<0){
             calculated_arg_of_latitude=(2*M_PI-calculated_arg_of_latitude);
         }

--- a/src/simulation_setup.cpp
+++ b/src/simulation_setup.cpp
@@ -46,7 +46,7 @@ int main()
 
     double timestep=2;
     double total_sim_time=25000;
-    double epsilon=pow(10,-11);
+    double epsilon=pow(10,-12);
     // sim_and_draw_orbit_gnuplot(satellite_vector_1,timestep,total_sim_time,epsilon);
 
     //Now some demonstrations of plotting orbital parameters
@@ -63,17 +63,19 @@ int main()
     std::vector<Satellite> satellite_vector_3={test_sat_7};
         sim_and_draw_orbit_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon);
 
-    sim_and_plot_orbital_elem_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"True Anomaly");
-    sim_and_plot_orbital_elem_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Orbital Rate");
-    sim_and_plot_orbital_elem_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Orbital Angular Acceleration");
+    // sim_and_plot_orbital_elem_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"True Anomaly");
+    sim_and_plot_orbital_elem_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Eccentricity");
 
-    sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"omega_y",false);
+    // sim_and_plot_orbital_elem_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Orbital Rate");
+    // sim_and_plot_orbital_elem_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Orbital Angular Acceleration");
+
+    // sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"omega_y",false);
 
     // sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"q_0",false);
     // sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"q_1",false);
     // sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"q_2",false);
     // sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"q_3",false);
-    sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Pitch",false);
+    // sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Pitch",false);
     // sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Yaw",false);
     // sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Roll",false);
 

--- a/src/simulation_setup.cpp
+++ b/src/simulation_setup.cpp
@@ -59,12 +59,16 @@ int main()
     total_sim_time=9952;
     // sim_and_plot_orbital_elem_gnuplot(satellite_vector_2,timestep,total_sim_time,epsilon,"Argument of Periapsis");
     Satellite test_sat_7("../input_7.json");
-
+    std::array<double,3> torque_direction={0,-1,0};
+    double torque_magnitude=0.0005; //N
+    double t_torque_start=3000;
+    double t_torque_end=3002;
+    test_sat_7.add_bodyframe_torque_profile(torque_direction,torque_magnitude,t_torque_start,t_torque_end);
     std::vector<Satellite> satellite_vector_3={test_sat_7};
-        sim_and_draw_orbit_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon);
+    // sim_and_draw_orbit_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon);
 
     // sim_and_plot_orbital_elem_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"True Anomaly");
-    sim_and_plot_orbital_elem_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Eccentricity");
+    // sim_and_plot_orbital_elem_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Eccentricity");
 
     // sim_and_plot_orbital_elem_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Orbital Rate");
     // sim_and_plot_orbital_elem_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Orbital Angular Acceleration");
@@ -75,7 +79,7 @@ int main()
     // sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"q_1",false);
     // sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"q_2",false);
     // sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"q_3",false);
-    // sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Pitch",false);
+    sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Pitch",false);
     // sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Yaw",false);
     // sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Roll",false);
 

--- a/src/simulation_setup.cpp
+++ b/src/simulation_setup.cpp
@@ -6,6 +6,26 @@ int main()
 {
     Satellite test_sat_1("../input.json");
 
+    // double epsilon=pow(10,-9);
+    // double test_timestep=1;
+    // for (size_t ind=0;ind<10;ind++){
+    //     std::cout << "Timestep index: " << ind << "\n";
+    //     std::pair<double,int> output_pair=test_sat_1.evolve_RK45(epsilon,test_timestep);
+    //     double next_timestep=output_pair.first;
+    //     std::cout << "next timestep: " << next_timestep << "\n";
+    //     int error_code=output_pair.second;
+    //     test_timestep=next_timestep;
+    //     std::cout << "Roll: " << test_sat_1.get_attitude_val("Roll") << "\n";
+    //     std::cout << "Pitch: " << test_sat_1.get_attitude_val("Pitch")<< "\n";
+    //     std::cout << "Yaw: " << test_sat_1.get_attitude_val("Yaw")<< "\n";
+    //     std::cout << "omega_x: " << test_sat_1.get_attitude_val("omega_x")<< "\n";
+    //     std::cout << "omega_y: " << test_sat_1.get_attitude_val("omega_y")<< "\n";
+    //     std::cout << "omega_z: " << test_sat_1.get_attitude_val("omega_z")<< "\n";
+    //     std::cout << "q_0: " << test_sat_1.get_attitude_val("q_0")<< "\n";
+    //     std::cout << "q_1: " << test_sat_1.get_attitude_val("q_1")<< "\n";
+    //     std::cout << "q_2: " << test_sat_1.get_attitude_val("q_2")<< "\n";
+    //     std::cout << "q_3: " << test_sat_1.get_attitude_val("q_3")<< "\n";
+    // }
     std::array<double,3> LVLH_thrust_direction={1,0,0};
     double thrust_magnitude=100; //N
     double t_thrust_start=5000;
@@ -27,7 +47,7 @@ int main()
     double timestep=2;
     double total_sim_time=25000;
     double epsilon=pow(10,-11);
-    sim_and_draw_orbit_gnuplot(satellite_vector_1,timestep,total_sim_time,epsilon);
+    // sim_and_draw_orbit_gnuplot(satellite_vector_1,timestep,total_sim_time,epsilon);
 
     //Now some demonstrations of plotting orbital parameters
     Satellite test_sat_4("../input_4.json");
@@ -36,7 +56,26 @@ int main()
 
 
     std::vector<Satellite> satellite_vector_2={test_sat_4,test_sat_5,test_sat_6};
-    total_sim_time=50000;
-    sim_and_plot_orbital_elem_gnuplot(satellite_vector_2,timestep,total_sim_time,epsilon,"Argument of Periapsis");
+    total_sim_time=9952;
+    // sim_and_plot_orbital_elem_gnuplot(satellite_vector_2,timestep,total_sim_time,epsilon,"Argument of Periapsis");
+    Satellite test_sat_7("../input_7.json");
+
+    std::vector<Satellite> satellite_vector_3={test_sat_7};
+        sim_and_draw_orbit_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon);
+
+    sim_and_plot_orbital_elem_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"True Anomaly");
+    sim_and_plot_orbital_elem_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Orbital Rate");
+    sim_and_plot_orbital_elem_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Orbital Angular Acceleration");
+
+    sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"omega_y",false);
+
+    // sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"q_0",false);
+    // sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"q_1",false);
+    // sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"q_2",false);
+    // sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"q_3",false);
+    sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Pitch",false);
+    // sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Yaw",false);
+    // sim_and_plot_attitude_evolution_gnuplot(satellite_vector_3,timestep,total_sim_time,epsilon,"Roll",false);
+
     return 0;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -5,6 +5,9 @@
 
 using Eigen::Matrix3d;
 using Eigen::Vector3d;
+using Eigen::Vector4d;
+using Eigen::Matrix4d;
+
 
 
 //"manual" version, via dot products and cross products with position and velocity vectors
@@ -422,3 +425,27 @@ void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,do
 // }
 
 
+
+
+std::array<double,4> bodyframe_quaternion_deriv(std::array<double,4> input_bodyframe_quaternion,double input_w_1, double input_w_2, double input_w_3){
+
+    //Assumes quaternions are input as [q_0, q_1, q_2, q_3] and omega is the spacecraft "body rate", represented in the body frame, w.r.t. a chosen reference frame
+    //Ref: https://ntrs.nasa.gov/api/citations/20240009554/downloads/Space%20Attitude%20Development%20Control.pdf
+
+    //Let's do this with Eigen so we can use matrix multiplication easily
+    Vector4d input_body_quaternion;
+    input_body_quaternion << input_bodyframe_quaternion.at(0),input_bodyframe_quaternion.at(1),input_bodyframe_quaternion.at(2),input_bodyframe_quaternion.at(3);
+
+    Matrix4d coeff_mat;
+    coeff_mat << 0,-input_w_1,-input_w_2,-input_w_3,
+                 input_w_1, 0, input_w_3, -input_w_2,
+                 input_w_2, -input_w_3, 0, input_w_1,
+                 input_w_3, input_w_2, -input_w_1, 0;
+
+    Vector4d quaternion_deriv_vec= 0.5*coeff_mat*input_body_quaternion;
+    std::array<double,4> quaternion_deriv_array;
+    for (size_t ind=0;ind<quaternion_deriv_array.size();ind++){
+        quaternion_deriv_array.at(ind)=quaternion_deriv_vec(ind);
+    }
+    return quaternion_deriv_array;
+}   

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -909,7 +909,7 @@ std::array<double,3> convert_quaternion_to_roll_yaw_pitch_angles(std::array<doub
     //Again, here I'm going off the pitch-yaw-roll sequence used in https://ntrs.nasa.gov/api/citations/19770024112/downloads/19770024112.pdf
     //Where the angles which defined the orbiter attitude with respect to LVLH are [A]_from_LVLH_to_BY = Rx(roll)*R_z(yaw)*R_y(pitch)
 
-    Vector3d v3={1,0,0}; //unit vector in direction of last rotation performed, which in this sequence is the x unit vector
+    Vector3d v3={0,1,0}; //unit vector in direction of last rotation performed, which in this sequence is the y unit vector
     Quaterniond eigen_quaternion(input_quaternion.at(0),input_quaternion.at(1),input_quaternion.at(2),input_quaternion.at(3));
     eigen_quaternion.normalize(); //Just in case
     Matrix3d rotation_matrix=eigen_quaternion.toRotationMatrix();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2,13 +2,25 @@
 #include <cmath>
 #include "Satellite.h"
 #include <Eigen/Dense>
+#include <Eigen/Geometry>
 
 using Eigen::Matrix3d;
 using Eigen::Vector3d;
 using Eigen::Vector4d;
 using Eigen::Matrix4d;
+using Eigen::Quaterniond;
 
-
+Vector4d quaternion_multiplication(Vector4d quaternion_1, Vector4d quaternion_2){
+    Vector3d quat_1_vec_component={quaternion_1(1),quaternion_1(2),quaternion_1(3)}; //Here adopting convention that scalar part is first element of quaternion
+    Vector3d quat_2_vec_component={quaternion_2(1),quaternion_2(2),quaternion_2(3)};
+    Vector3d vec_part_of_result=quaternion_1(0)*quat_2_vec_component + quaternion_2(0)*quat_1_vec_component + quat_1_vec_component.cross(quat_2_vec_component);
+    Vector4d result;
+    result << quaternion_1(0)*quaternion_2(0)-quat_1_vec_component.dot(quat_2_vec_component),
+              vec_part_of_result(0),
+              vec_part_of_result(1),
+              vec_part_of_result(2);
+    return result;
+}
 
 //"manual" version, via dot products and cross products with position and velocity vectors
 std::array<double,3> convert_LVLH_to_ECI_manual(std::array<double,3> input_LVLH_vec,std::array<double,3> input_position_vec,std::array<double,3> input_velocity_vec){
@@ -294,7 +306,7 @@ std::array<double,6> RK45_deriv_function_orbit_position_and_velocity(std::array<
 
 
 
-void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,double input_timestep, double input_total_sim_time, double input_epsilon){
+void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,double input_timestep, double input_total_sim_time, double input_epsilon, bool perturbation){
     if (input_satellite_vector.size()<1){
         std::cout << "No input Satellite objects\n";
         return;
@@ -324,7 +336,7 @@ void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,do
 
         //plotting
         //first let's set the stage for plotting the Earth
-        fprintf(gnuplot_pipe,"R_Earth=%f\n",radius_Earth);
+        fprintf(gnuplot_pipe,"R_Earth=%.17g\n",radius_Earth);
         fprintf(gnuplot_pipe,"set isosamples 50,50\n");
         fprintf(gnuplot_pipe,"set parametric\n");
         fprintf(gnuplot_pipe,"set urange [-pi/2:pi/2]\n");
@@ -379,7 +391,7 @@ void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,do
         for (size_t satellite_index=0;satellite_index<input_satellite_vector.size();satellite_index++){
             Satellite current_satellite=input_satellite_vector.at(satellite_index);
             std::array<double,3> initial_position=current_satellite.get_ECI_position();
-            fprintf(gnuplot_pipe,"%f %f %f\n",initial_position.at(0),initial_position.at(1),initial_position.at(2));
+            fprintf(gnuplot_pipe,"%.17g %.17g %.17g\n",initial_position.at(0),initial_position.at(1),initial_position.at(2));
     
     
             std::array<double,3> evolved_position={};
@@ -387,7 +399,7 @@ void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,do
             double timestep_to_use=input_timestep;
             double current_satellite_time=current_satellite.get_instantaneous_time();
             while (current_satellite_time<input_total_sim_time){
-                std::pair<double,int> new_timestep_and_error_code=current_satellite.evolve_RK45(input_epsilon,timestep_to_use);
+                std::pair<double,int> new_timestep_and_error_code=current_satellite.evolve_RK45(input_epsilon,timestep_to_use,perturbation);
                 double new_timestep=new_timestep_and_error_code.first;
                 int error_code=new_timestep_and_error_code.second;
                 if (error_code!=0){
@@ -400,7 +412,7 @@ void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,do
                 timestep_to_use=new_timestep;
                 evolved_position=current_satellite.get_ECI_position();
                 current_satellite_time=current_satellite.get_instantaneous_time();
-                fprintf(gnuplot_pipe,"%f %f %f\n",evolved_position.at(0),evolved_position.at(1),evolved_position.at(2));
+                fprintf(gnuplot_pipe,"%.17g %.17g %.17g\n",evolved_position.at(0),evolved_position.at(1),evolved_position.at(2));
             }
             fprintf(gnuplot_pipe,"e\n");
 
@@ -420,7 +432,7 @@ void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,do
 }
 
 
-void sim_and_plot_orbital_elem_gnuplot(std::vector<Satellite> input_satellite_vector,double input_timestep, double input_total_sim_time, double input_epsilon,std::string input_orbital_element_name){
+void sim_and_plot_orbital_elem_gnuplot(std::vector<Satellite> input_satellite_vector,double input_timestep, double input_total_sim_time, double input_epsilon,std::string input_orbital_element_name,bool perturbation){
     if (input_satellite_vector.size()<1){
         std::cout << "No input Satellite objects\n";
         return;
@@ -498,7 +510,7 @@ void sim_and_plot_orbital_elem_gnuplot(std::vector<Satellite> input_satellite_ve
             Satellite current_satellite=input_satellite_vector.at(satellite_index);
             double val=current_satellite.get_orbital_element(input_orbital_element_name);
             double current_satellite_time=current_satellite.get_instantaneous_time();
-            fprintf(gnuplot_pipe,"%f %f\n",current_satellite_time,val);
+            fprintf(gnuplot_pipe,"%.17g %.17g\n",current_satellite_time,val);
     
     
             double evolved_val={0};
@@ -506,7 +518,7 @@ void sim_and_plot_orbital_elem_gnuplot(std::vector<Satellite> input_satellite_ve
             double timestep_to_use=input_timestep;
             current_satellite_time=current_satellite.get_instantaneous_time();
             while (current_satellite_time<input_total_sim_time){
-                std::pair<double,int> new_timestep_and_error_code=current_satellite.evolve_RK45(input_epsilon,timestep_to_use);
+                std::pair<double,int> new_timestep_and_error_code=current_satellite.evolve_RK45(input_epsilon,timestep_to_use,perturbation);
                 double new_timestep=new_timestep_and_error_code.first;
                 int error_code=new_timestep_and_error_code.second;
 
@@ -520,7 +532,7 @@ void sim_and_plot_orbital_elem_gnuplot(std::vector<Satellite> input_satellite_ve
                 timestep_to_use=new_timestep;
                 evolved_val=current_satellite.get_orbital_element(input_orbital_element_name);
                 current_satellite_time=current_satellite.get_instantaneous_time();
-                fprintf(gnuplot_pipe,"%f %f\n",current_satellite_time,evolved_val);
+                fprintf(gnuplot_pipe,"%.17g %.17g\n",current_satellite_time,evolved_val);
             }
             fprintf(gnuplot_pipe,"e\n");
 
@@ -541,69 +553,34 @@ void sim_and_plot_orbital_elem_gnuplot(std::vector<Satellite> input_satellite_ve
 
 
 
-// Matrix3d z_rot_matrix(double input_angle){
-//     Matrix3d z_rotation_matrix;
-//     z_rotation_matrix << cos(input_angle), -sin(input_angle), 0,
-//                  sin(input_angle), cos(input_angle), 0,
-//                  0,0,1;
+Matrix3d z_rot_matrix(double input_angle){
+    Matrix3d z_rotation_matrix;
+    z_rotation_matrix << cos(input_angle), -sin(input_angle), 0,
+                 sin(input_angle), cos(input_angle), 0,
+                 0,0,1;
 
-//     return z_rotation_matrix;
-// }
+    return z_rotation_matrix;
+}
 
-// Matrix3d y_rot_matrix(double input_angle){
-//     Matrix3d y_rotation_matrix;
-//     y_rotation_matrix << cos(input_angle), 0, sin(input_angle),
-//                         0,1,0,
-//                         -sin(input_angle), 0, cos(input_angle);
+Matrix3d y_rot_matrix(double input_angle){
+    Matrix3d y_rotation_matrix;
+    y_rotation_matrix << cos(input_angle), 0, sin(input_angle),
+                        0,1,0,
+                        -sin(input_angle), 0, cos(input_angle);
 
-//     return y_rotation_matrix;
-// }
-
-
-// Matrix3d x_rot_matrix(double input_angle){
-//     Matrix3d x_rotation_matrix;
-//     x_rotation_matrix << 1,0,0,
-//                          0, cos(input_angle), -sin(input_angle),
-//                          0, sin(input_angle), cos(input_angle);
-
-//     return x_rotation_matrix;
-// }
+    return y_rotation_matrix;
+}
 
 
-// std::array<double,3> convert_rotated_body_frame_to_unrotated_body_frame(std::array<double,3> input_rotated_body_frame_array,double theta, double phi, double psi){
-//     Vector3d rotated_body_frame_vec;
-//     rotated_body_frame_vec << input_rotated_body_frame_array.at(0), input_rotated_body_frame_array.at(1), input_rotated_body_frame_array.at(2);
-//     //build A matrix
-//     Matrix3d A_mat;
-//     A_mat << cos(phi)*cos(psi) - cos(theta)*sin(phi)*sin(psi), -cos(phi)*sin(psi) - cos(theta)*sin(phi)*cos(psi), sin(theta)*sin(phi),
-//              sin(phi)*cos(psi) + cos(theta)*cos(phi)*sin(psi), -sin(phi)*sin(psi) + cos(theta)*cos(phi)*cos(psi), -sin(theta)*cos(phi),
-//              sin(theta)*sin(psi), sin(theta)*cos(psi), cos(theta);
+Matrix3d x_rot_matrix(double input_angle){
+    Matrix3d x_rotation_matrix;
+    x_rotation_matrix << 1,0,0,
+                         0, cos(input_angle), -sin(input_angle),
+                         0, sin(input_angle), cos(input_angle);
 
-//     Vector3d unrotated_body_frame_vec=A_mat*rotated_body_frame_vec;
-//     std::array<double,3> unrotated_body_frame_array;
-//     for (size_t ind=0;ind<3;ind++){
-//         unrotated_body_frame_array.at(ind)=unrotated_body_frame_vec(ind);
-//     }
-//     return unrotated_body_frame_array;
-// }
+    return x_rotation_matrix;
+}
 
-
-
-
-// std::array<double,3> calculate_body_frame_angular_acceleration(const double input_spacecraft_moi,std::vector<std::array<double,3>> input_vec_of_torque_vectors_in_body_frame)
-// {
-//     //Body-frame angular acceleration calculated from alpha_i=tau_i/I for torque tau, MOI I
-
-//     std::array<double,3> body_frame_angular_acceleration={0,0,0};
-
-//     for (std::array<double,3> body_frame_torque_vec : input_vec_of_torque_vectors_in_body_frame){
-//         for (size_t coord_ind=0;coord_ind<3;coord_ind++){
-//             acceleration_vec.at(coord_ind)+=(body_frame_torque_vec.at(coord_ind)/input_spacecraft_moi);
-//         }
-
-//     }
-//     return body_frame_angular_acceleration;
-// }
 
 
 
@@ -630,3 +607,327 @@ std::array<double,4> bodyframe_quaternion_deriv(std::array<double,4> input_bodyf
     }
     return quaternion_deriv_array;
 }   
+
+
+void sim_and_plot_attitude_evolution_gnuplot(std::vector<Satellite> input_satellite_vector,double input_timestep, double input_total_sim_time,double input_epsilon,std::string input_plotted_val_name, bool perturbation){
+    if (input_satellite_vector.size()<1){
+        std::cout << "No input Satellite objects\n";
+        return;
+    }
+
+    //first, open "pipe" to gnuplot
+    FILE *gnuplot_pipe = popen("gnuplot", "w");
+    //if it exists
+    if (gnuplot_pipe){
+
+        fprintf(gnuplot_pipe,"set terminal qt size 600,400 font 'Helvetica,14'\n");
+        //formatting
+        fprintf(gnuplot_pipe,"set xlabel 'Time [s]'\n");
+        if ((input_plotted_val_name=="omega_x")||(input_plotted_val_name=="omega_y")||(input_plotted_val_name=="omega_z")){
+            fprintf(gnuplot_pipe,"set ylabel '%s [rad/s]'\n",input_plotted_val_name.c_str());
+        }
+        else if ((input_plotted_val_name=="Roll")||(input_plotted_val_name=="Pitch")||(input_plotted_val_name=="Yaw")){
+            fprintf(gnuplot_pipe,"set ylabel '%s [rad]'\n",input_plotted_val_name.c_str());
+        }
+        else {
+            fprintf(gnuplot_pipe,"set ylabel '%s'\n",input_plotted_val_name.c_str());
+        }
+        fprintf(gnuplot_pipe,"set title '%s simulated up to time %.2f s'\n",input_plotted_val_name.c_str(), input_total_sim_time);
+        fprintf(gnuplot_pipe,"set key right bottom\n");
+
+
+        //plotting
+
+
+        //first satellite
+        Satellite current_satellite=input_satellite_vector.at(0);
+        if (input_satellite_vector.size()==1){
+            if (current_satellite.plotting_color_.size()>0){
+                fprintf(gnuplot_pipe,"plot '-' using 1:2 with lines lw 1 lc rgb '%s' title '%s' \n",current_satellite.plotting_color_.c_str(),current_satellite.get_name().c_str());
+            }
+            else {
+                fprintf(gnuplot_pipe,"pplot '-' using 1:2 with lines lw 1 title '%s' \n",current_satellite.get_name().c_str());
+            }
+            
+        }
+
+        else {
+            if (current_satellite.plotting_color_.size()>0){
+                fprintf(gnuplot_pipe,"plot '-' using 1:2 with lines lw 1 lc rgb '%s' title '%s'\\\n",current_satellite.plotting_color_.c_str(),current_satellite.get_name().c_str());
+            }
+            else {
+                fprintf(gnuplot_pipe,"plot '-' using 1:2 with lines lw 1 title '%s'\\\n",current_satellite.get_name().c_str());
+            }
+        }
+
+        for (size_t satellite_index=1;satellite_index<input_satellite_vector.size();satellite_index++){
+            current_satellite=input_satellite_vector.at(satellite_index);
+            if (satellite_index<input_satellite_vector.size()-1){
+                if (current_satellite.plotting_color_.size()>0){
+                    fprintf(gnuplot_pipe,",'-' using 1:2 with lines lw 1 lc rgb '%s' title '%s' \\\n",current_satellite.plotting_color_.c_str(),current_satellite.get_name().c_str());
+                }
+                else {
+                    fprintf(gnuplot_pipe,",'-' using 1:2 with lines lw 1 title '%s' \\\n",current_satellite.get_name().c_str());
+                }
+                
+            }
+
+            else {
+                if (current_satellite.plotting_color_.size()>0){
+                    fprintf(gnuplot_pipe,",'-' using 1:2 with lines lw 1 lc rgb '%s' title '%s'\n",current_satellite.plotting_color_.c_str(),current_satellite.get_name().c_str());
+                }
+                else {
+                    fprintf(gnuplot_pipe,",'-' using 1:2 with lines lw 1 title '%s'\n",current_satellite.get_name().c_str());
+                }
+            }
+        }
+
+        //now the orbit data, inline, one satellite at a time
+        for (size_t satellite_index=0;satellite_index<input_satellite_vector.size();satellite_index++){
+            Satellite current_satellite=input_satellite_vector.at(satellite_index);
+            double val=current_satellite.get_attitude_val(input_plotted_val_name);
+            double current_satellite_time=current_satellite.get_instantaneous_time();
+            fprintf(gnuplot_pipe,"%.17g %.17g\n",current_satellite_time,val);
+    
+    
+            double evolved_val={0};
+    
+            double timestep_to_use=input_timestep;
+            current_satellite_time=current_satellite.get_instantaneous_time();
+            while (current_satellite_time<input_total_sim_time){
+                std::pair<double,int> new_timestep_and_error_code=current_satellite.evolve_RK45(input_epsilon,timestep_to_use,perturbation);
+                double new_timestep=new_timestep_and_error_code.first;
+                int error_code=new_timestep_and_error_code.second;
+
+                if (error_code!=0){
+                    std::cout << "Error detected, halting visualization\n";
+                    fprintf(gnuplot_pipe,"e\n");
+                    fprintf(gnuplot_pipe,"exit \n");
+                    pclose(gnuplot_pipe);
+                    return;
+                }
+                timestep_to_use=new_timestep;
+                evolved_val=current_satellite.get_attitude_val(input_plotted_val_name);
+                current_satellite_time=current_satellite.get_instantaneous_time();
+                fprintf(gnuplot_pipe,"%.17g %.17g\n",current_satellite_time,evolved_val);
+            }
+            fprintf(gnuplot_pipe,"e\n");
+
+        }
+        fprintf(gnuplot_pipe,"pause mouse keypress\n");
+
+        fprintf(gnuplot_pipe,"exit \n");
+        pclose(gnuplot_pipe);
+
+
+    }
+    else {
+        std::cout << "gnuplot not found";
+    }
+
+    return;
+}
+
+
+Matrix3d rollyawpitch_bodyframe_to_LVLH_matrix(double input_roll, double input_pitch, double input_yaw){
+    //Going off convention in https://ntrs.nasa.gov/api/citations/19770024112/downloads/19770024112.pdf which appears to be first rotating by pitch, then yaw, then roll
+    // This is a convention where the rotations are performed as: v_body = R_x(roll)R_z(yaw)R_y(pitch)v_LVLH
+    // That's an intrinsic Tait-Bryan xzy sequence, following convention described in https://en.wikipedia.org/wiki/Rotation_matrix 
+    // To my understanding, this is equivalent to an extrinsic Tait-Bryan yzx sequence
+
+
+    //First going to construct LVLH_to_bodyframe matrix, then take transpose to make it the bodyframe_to_LVLH matrix
+    Matrix3d bodyframe_to_LVLH_matrix= x_rot_matrix(input_roll)*z_rot_matrix(input_yaw)*y_rot_matrix(input_pitch);
+    bodyframe_to_LVLH_matrix.transpose();
+
+    return bodyframe_to_LVLH_matrix;
+}
+
+
+
+std::array<double,4> rollyawpitch_angles_to_quaternion(double input_roll, double input_pitch, double input_yaw){
+    //Refs : https://www.euclideanspace.com/maths/geometry/rotations/conversions/eulerToQuaternion/Euler%20to%20quat.pdf  
+    // and https://ntrs.nasa.gov/api/citations/19770024112/downloads/19770024112.pdf 
+    Vector4d q_pitch={cos(input_pitch/2),0.0,sin(input_pitch/2),0.0};
+    Vector4d q_yaw={cos(input_yaw/2),0.0,0.0,sin(input_yaw/2)};
+    Vector4d q_roll={cos(input_roll/2),sin(input_roll/2),0.0,0.0};
+    Vector4d q_tot=quaternion_multiplication(q_roll,quaternion_multiplication(q_yaw,q_pitch));
+    std::array<double,4> output_quaternion={q_tot(0),q_tot(1),q_tot(2),q_tot(3)};
+    return output_quaternion;
+}   
+
+
+
+Matrix3d LVLH_to_body_transformation_matrix_from_quaternion(std::array<double,4> input_bodyframe_quaternion_relative_to_LVLH){
+    //Ref: https://ntrs.nasa.gov/api/citations/20240009554/downloads/Space%20Attitude%20Development%20Control.pdf section 4.3.1
+    double q0=input_bodyframe_quaternion_relative_to_LVLH.at(0);
+    double q1=input_bodyframe_quaternion_relative_to_LVLH.at(1);
+    double q2=input_bodyframe_quaternion_relative_to_LVLH.at(2);
+    double q3=input_bodyframe_quaternion_relative_to_LVLH.at(3);
+
+    Matrix3d LVLH_to_body_mat;
+    LVLH_to_body_mat << 2*q0*q0 - 1 + 2*q1*q1 , 2*q1*q2 + 2*q0*q3 , 2*q1*q3 - 2*q0*q2,
+                        2*q1*q2 - 2*q0*q3, 2*q0*q0 - 1 + 2*q2*q2 , 2*q2*q3 + 2*q0*q1,
+                        2*q1*q3 + 2*q0*q2, 2*q2*q3 - 2*q0*q1, 2*q0*q0 - 1 + 2*q3*q3;
+    
+    return LVLH_to_body_mat;
+}
+
+std::array<double,3> calculate_spacecraft_bodyframe_angular_acceleration( Matrix3d J_matrix, std::vector<BodyframeTorqueProfile> input_bodyframe_torque_profile_list,  Vector3d input_omega_I,  double input_orbital_angular_acceleration, Vector3d input_omega_bodyframe_wrt_LVLH_in_body_frame, Matrix3d input_LVLH_to_bodyframe_transformation_matrix, Vector3d input_omega_LVLH_wrt_inertial_in_LVLH, double input_evaluation_time){
+    //Using approach from https://ntrs.nasa.gov/api/citations/20240009554/downloads/Space%20Attitude%20Development%20Control.pdf , Ch. 4 especially
+    //Objective: calculate omega_dot in spacecraft body frame w.r.t. the LVLH frame, expressed in the spacecraft body frame
+    //Disturbance torques, if eventually added in, should just be more torque profiles in the satellite object's list of torque profiles
+    //So the input_torques vector includes both disturbance and control torques
+    Vector3d bodyframe_torque_vec={0,0,0};
+
+    for (BodyframeTorqueProfile bodyframe_torque_profile : input_bodyframe_torque_profile_list){
+
+        if ((input_evaluation_time>=bodyframe_torque_profile.t_start_)&&(input_evaluation_time<=bodyframe_torque_profile.t_end_)){
+            for (size_t ind=0;ind<3;ind++){
+                bodyframe_torque_vec(ind)+=bodyframe_torque_profile.bodyframe_torque_list.at(ind);
+            }
+        }
+    }
+    
+    Vector3d omega_lvlh_dot={0,-input_orbital_angular_acceleration,0};
+    Matrix3d inverted_J_matrix=J_matrix;
+    inverted_J_matrix.inverse();
+
+    Vector3d comp1=-inverted_J_matrix*(input_omega_I.cross(J_matrix*input_omega_I));
+    Vector3d comp2=inverted_J_matrix*bodyframe_torque_vec;
+    Vector3d comp3=input_omega_bodyframe_wrt_LVLH_in_body_frame.cross(input_LVLH_to_bodyframe_transformation_matrix*input_omega_LVLH_wrt_inertial_in_LVLH);
+    Vector3d omega_dot_vec_LVLH_wrt_inertial_in_ECI = {0,-input_orbital_angular_acceleration,0};
+    Vector3d comp4= - input_LVLH_to_bodyframe_transformation_matrix*omega_dot_vec_LVLH_wrt_inertial_in_ECI;
+
+    Vector3d angular_acceleration_bodyframe_wrt_LVLH_in_bodyframe=comp1+comp2+comp3+comp4;
+    std::array<double,3> angular_acceleration_bodyframe_wrt_LVLH_in_bodyframe_array={angular_acceleration_bodyframe_wrt_LVLH_in_bodyframe(0),angular_acceleration_bodyframe_wrt_LVLH_in_bodyframe(1),angular_acceleration_bodyframe_wrt_LVLH_in_bodyframe(2)};
+
+    return angular_acceleration_bodyframe_wrt_LVLH_in_bodyframe_array;
+}
+
+
+Vector4d quaternion_kinematics_equation(Vector4d quaternion_of_bodyframe_relative_to_ref_frame, Vector3d angular_velocity_vec_wrt_ref_frame_in_body_frame){
+    //Ref: https://ntrs.nasa.gov/api/citations/20240009554/downloads/Space%20Attitude%20Development%20Control.pdf Section 4.1.2
+
+    //Here assuming scalar component is first in quaternion
+    Vector3d vec_component_of_quaternion={quaternion_of_bodyframe_relative_to_ref_frame(1),quaternion_of_bodyframe_relative_to_ref_frame(2),quaternion_of_bodyframe_relative_to_ref_frame(3)};
+    double q_0_dot=(-0.5)*angular_velocity_vec_wrt_ref_frame_in_body_frame.dot(vec_component_of_quaternion);
+    Vector3d vec_q_dot=(-0.5)*angular_velocity_vec_wrt_ref_frame_in_body_frame.cross(vec_component_of_quaternion) + (0.5)*quaternion_of_bodyframe_relative_to_ref_frame(0)*angular_velocity_vec_wrt_ref_frame_in_body_frame;
+
+    Vector4d quaternion_derivative;
+    quaternion_derivative << q_0_dot, vec_q_dot(0),vec_q_dot(1), vec_q_dot(2);
+
+    return quaternion_derivative;
+}
+
+std::array<double,7> RK45_satellite_body_angular_deriv_function( std::array<double,7> combined_bodyframe_angular_array, Matrix3d J_matrix, std::vector<BodyframeTorqueProfile> input_bodyframe_torque_profile_list,  Vector3d input_omega_I,  double input_orbital_angular_acceleration, Matrix3d input_LVLH_to_bodyframe_transformation_matrix, Vector3d input_omega_LVLH_wrt_inertial_in_LVLH, double input_evaluation_time){
+    //Setting this up for an RK45 step with y={q_0,q_1,q_2,q_3,omega_1,omega_2,omega_3}
+    //Objective is to produce dy/dt
+    //Input quaternion should be quaternion of bodyframe relative to LVLH 
+    std::array<double,7> combined_angular_derivative_array={0,0,0,0,0,0,0};
+    Vector4d quaternion={combined_bodyframe_angular_array.at(0),combined_bodyframe_angular_array.at(1),combined_bodyframe_angular_array.at(2),combined_bodyframe_angular_array.at(3)};
+    Vector3d body_angular_velocity_vec_wrt_LVLH_in_body_frame={combined_bodyframe_angular_array.at(4),combined_bodyframe_angular_array.at(5),combined_bodyframe_angular_array.at(6)};
+    Vector4d quaternion_derivative=quaternion_kinematics_equation(quaternion,body_angular_velocity_vec_wrt_LVLH_in_body_frame);
+    std::array<double,3> body_angular_acceleration_vec_wrt_LVLH_in_body_frame= calculate_spacecraft_bodyframe_angular_acceleration(J_matrix,input_bodyframe_torque_profile_list, input_omega_I, input_orbital_angular_acceleration, body_angular_velocity_vec_wrt_LVLH_in_body_frame,  input_LVLH_to_bodyframe_transformation_matrix, input_omega_LVLH_wrt_inertial_in_LVLH,input_evaluation_time);
+
+    for (size_t ind=0;ind<4;ind++){
+        combined_angular_derivative_array.at(ind)=quaternion_derivative(ind);
+    }
+    for (size_t ind=4;ind<7;ind++){
+        combined_angular_derivative_array.at(ind)=body_angular_acceleration_vec_wrt_LVLH_in_body_frame.at(ind-4);
+    }
+
+    return combined_angular_derivative_array;
+}
+
+Vector3d calculate_omega_I(Vector3d input_bodyframe_ang_vel_vector_wrt_lvlh, Matrix3d input_LVLH_to_bodyframe_transformation_matrix,double input_orbital_rate){
+    //Eq. 4.17 in https://ntrs.nasa.gov/api/citations/20240009554/downloads/Space%20Attitude%20Development%20Control.pdf
+    Vector3d omega_LVLH_wrt_inertial_in_LVLH={0,-input_orbital_rate,0};
+    Vector3d omega_I= input_bodyframe_ang_vel_vector_wrt_lvlh + input_LVLH_to_bodyframe_transformation_matrix*omega_LVLH_wrt_inertial_in_LVLH;
+    return omega_I;
+}
+
+Matrix3d construct_J_matrix(double input_Jxx, double input_Jyy, double input_Jzz){
+    Matrix3d J_matrix=Matrix3d::Zero();
+    J_matrix(0,0)=input_Jxx;
+    J_matrix(1,1)=input_Jyy;
+    J_matrix(2,2)=input_Jzz;
+    return J_matrix;
+}
+
+
+
+
+std::array<double,13> RK45_combined_orbit_position_velocity_attitude_deriv_function( std::array<double,13> combined_position_velocity_bodyframe_angular_array,Matrix3d J_matrix, std::vector<BodyframeTorqueProfile> input_bodyframe_torque_profile_list,  Vector3d input_omega_I,  double input_orbital_angular_acceleration, Matrix3d input_LVLH_to_bodyframe_transformation_matrix, Vector3d input_omega_LVLH_wrt_inertial_in_LVLH, double input_spacecraft_mass,std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,double input_evaluation_time,double input_inclination, double input_arg_of_periapsis, double input_true_anomaly,bool perturbation){
+    //Input vector is in the form of {ECI_position, ECI_velocity,bodyframe_quaternion_to_LVLH,bodyframe_omega_wrt_LVLH}
+    //Objective is to output derivative of that vector
+    std::array<double,13> derivative_vec;
+    std::array<double,6> combined_position_and_velocity_array;
+    std::array<double,7> combined_angular_array;
+
+    for (size_t ind=0;ind<combined_position_and_velocity_array.size();ind++){
+        combined_position_and_velocity_array.at(ind)=combined_position_velocity_bodyframe_angular_array.at(ind);
+    }
+    for (size_t ind=0;ind<combined_angular_array.size();ind++){
+        combined_angular_array.at(ind)=combined_position_velocity_bodyframe_angular_array.at(ind+combined_position_and_velocity_array.size());
+    }
+    std::array<double,6> orbital_position_and_velocity_derivative_array= RK45_deriv_function_orbit_position_and_velocity( combined_position_and_velocity_array, input_spacecraft_mass,input_list_of_thrust_profiles_LVLH, input_evaluation_time, input_inclination,  input_arg_of_periapsis,  input_true_anomaly, perturbation);
+
+
+
+    std::array<double,7> angular_derivative_array= RK45_satellite_body_angular_deriv_function(combined_angular_array, J_matrix,  input_bodyframe_torque_profile_list,   input_omega_I,   input_orbital_angular_acceleration,  input_LVLH_to_bodyframe_transformation_matrix,  input_omega_LVLH_wrt_inertial_in_LVLH,  input_evaluation_time);
+
+    for (size_t ind=0;ind<orbital_position_and_velocity_derivative_array.size();ind++){
+        derivative_vec.at(ind)=orbital_position_and_velocity_derivative_array.at(ind);
+    }
+    for (size_t ind=0;ind<angular_derivative_array.size();ind++){
+
+        derivative_vec.at(ind+orbital_position_and_velocity_derivative_array.size())=angular_derivative_array.at(ind);
+    }
+
+    return derivative_vec;
+
+}
+
+
+
+
+std::array<double,4> normalize_quaternion(std::array<double,4> input_quaternion){
+    double length=0;
+    for (size_t ind=0;ind<input_quaternion.size();ind++){
+        length+= (input_quaternion.at(ind)*input_quaternion.at(ind));
+    }
+    for (size_t ind=0;ind<input_quaternion.size();ind++){
+        input_quaternion.at(ind)/= sqrt(length);
+    }
+    return input_quaternion;
+}
+
+
+std::array<double,3> convert_quaternion_to_roll_yaw_pitch_angles(std::array<double,4> input_quaternion){
+    //Based on approach in https://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToEuler/quat_2_euler_paper_ver2-1.pdf
+    //Again, here I'm going off the pitch-yaw-roll sequence used in https://ntrs.nasa.gov/api/citations/19770024112/downloads/19770024112.pdf
+    //Where the angles which defined the orbiter attitude with respect to LVLH are [A]_from_LVLH_to_BY = Rx(roll)*R_z(yaw)*R_y(pitch)
+
+    Vector3d v3={1,0,0}; //unit vector in direction of last rotation performed, which in this sequence is the x unit vector
+    Quaterniond eigen_quaternion(input_quaternion.at(0),input_quaternion.at(1),input_quaternion.at(2),input_quaternion.at(3));
+    eigen_quaternion.normalize(); //Just in case
+    Matrix3d rotation_matrix=eigen_quaternion.toRotationMatrix();
+    Vector3d euler_angles=rotation_matrix.eulerAngles(0,2,1); //Eigen uses intrinsic convention, so this is an intrinsic XZY (denoted x-z'-y'' in the notation Wikipedia uses) or extrinsic YZX sequence corresponding to R_x R_z R_y (e.g., see https://arg.usask.ca/docs/skplatform/appendices/rotation_matrices.html)
+
+    double roll=euler_angles(0);
+    double yaw=euler_angles(1);
+    double pitch=euler_angles(2);
+
+    std::array<double,3> output_angle_vec={roll,yaw,pitch};
+    return output_angle_vec;
+}
+
+
+std::array<double,3> convert_array_from_LVLH_to_bodyframe(std::array<double,3> input_LVLH_frame_array,double input_roll, double input_yaw, double input_pitch){
+    Matrix3d transformation_matrix=rollyawpitch_bodyframe_to_LVLH_matrix( input_roll,  input_pitch,  input_yaw);
+    Vector3d input_LVLH_frame_vector={input_LVLH_frame_array.at(0),input_LVLH_frame_array.at(1),input_LVLH_frame_array.at(2)};
+    Vector3d bodyframe_vec=transformation_matrix*input_LVLH_frame_vector;
+    std::array<double,3> bodyframe_arr={bodyframe_vec(0),bodyframe_vec(1),bodyframe_vec(2)};
+    return bodyframe_arr;
+}


### PR DESCRIPTION
# Context
Up until now, I haven't added support for simulating the time evolution of the spacecraft's attitude, nor the ability to influence it via input parameters or torque profiles (analogous to the thrust profiles used for adjusting the spacecraft's orbital position and velocity). I wanted to make it such that the user could input specifications in terms of Euler angles (specifically, Tait-Bryan angles here) and body-frame angular velocities and torques, then have the code convert everything to quaternions under the hood for actual time evolution calculations to avoid the singularities of Euler angle-type parametrization, then translate back to angles for output/plotting. 

# Changes
- Added body-frame torque profile class representing constant-magnitude body-frame torques applied over specified periods of time, and the ability to add instances of these classes to Satellite objects similar to the LVLH thrust profiles
- Added attitude-related satellite attributes (angular velocities of spacecraft body frame, roll, pitch, yaw angles, quaternion components, J_ii components)
- Adding initial angular velocities of body frame w.r.t. LVLH frame and initial roll, pitch, yaw angles as optional input file parameters
- Modified RK45 evolution to take in a large combined vector (the y_n in the standard notation) containing orbital position, orbital velocity, and attitude-related values (quaternion components, angular velocities) so that all values evolve with the same stepsize
- Baselining an intrinsic x-z'-y'' sequence for now based on an old NASA doc
- Added support for plotting attitude-related values over time
- Increased precision of gnuplot-plotted values from default float precision
- Added machinery for various necessary conversions between quaternions, matrices, and Euler angles (though technically these are Tait-Bryan angles because all 3 axes are distinct)
- Changed how I create the arrays in the just-orbital-motion RK45 step implementation (and the new combined one) to align with how arrays elsewhere in the code are created
- Added perturbation boolean to plotting functions
- Added NaN detection for argument of latitude calculation

# Integration Tests
Must pass existing tests