### PR TITLE
Fixing bug in kinetic energy calculation, adding more orbit tests

### DIFF
--- a/include/Satellite.h
+++ b/include/Satellite.h
@@ -142,7 +142,7 @@ class Satellite {
 
     inclination_ = input_data.at("Inclination");
     // convert to radians
-    inclination_ *= (M_PI / 180);
+    inclination_ *= (M_PI / 180.0);
     if (inclination_ == 0) {
       throw std::invalid_argument(
           "Zero inclination orbits are not currently supported");
@@ -150,11 +150,11 @@ class Satellite {
 
     raan_ = input_data.at("RAAN");
     // convert to radians
-    raan_ *= (M_PI / 180);
+    raan_ *= (M_PI / 180.0);
 
     arg_of_periapsis_ = input_data.at("Argument of Periapsis");
     // convert to radians
-    arg_of_periapsis_ *= (M_PI / 180);
+    arg_of_periapsis_ *= (M_PI / 180.0);
 
     eccentricity_ = input_data.at("Eccentricity");
     // If circular orbit, arg of periapsis is undefined, using convention of
@@ -164,29 +164,29 @@ class Satellite {
     }
 
     a_ = input_data.at("Semimajor Axis");
-    a_ *= 1000;  // converting from km to m
+    a_ *= 1000.0;  // converting from km to m
 
     true_anomaly_ = input_data.at("True Anomaly");
     // convert to radians
-    true_anomaly_ *= (M_PI / 180);
+    true_anomaly_ *= (M_PI / 180.0);
 
     // making initial pitch angle an optional parameter
     if (input_data.find("Initial Pitch Angle") != input_data.end()) {
       pitch_angle_ = input_data.at("Initial Pitch Angle");
       // convert to radians
-      pitch_angle_ *= (M_PI / 180);
+      pitch_angle_ *= (M_PI / 180.0);
     }
     // making initial roll angle an optional parameter
     if (input_data.find("Initial Roll Angle") != input_data.end()) {
       roll_angle_ = input_data.at("Initial Roll Angle");
       // convert to radians
-      roll_angle_ *= (M_PI / 180);
+      roll_angle_ *= (M_PI / 180.0);
     }
     // making initial yaw angle an optional parameter
     if (input_data.find("Initial Yaw Angle") != input_data.end()) {
       yaw_angle_ = input_data.at("Initial Yaw Angle");
       // convert to radians
-      yaw_angle_ *= (M_PI / 180);
+      yaw_angle_ *= (M_PI / 180.0);
     }
 
     initialize_and_normalize_body_quaternion(roll_angle_, pitch_angle_,
@@ -249,6 +249,11 @@ class Satellite {
     return sqrt(pow(perifocal_velocity_.at(0), 2) +
                 pow(perifocal_velocity_.at(1), 2));
   }
+  double get_speed_ECI() {
+    return sqrt(pow(ECI_velocity_.at(0), 2) +
+                pow(ECI_velocity_.at(1), 2) +
+                pow(ECI_velocity_.at(2),2));
+  }
   double get_radius() {
     // shouldn't matter which frame I use, might as well use perifocal coords
     // since it's fewer operations (no W-direction component so can omit that
@@ -256,13 +261,18 @@ class Satellite {
     return sqrt(pow(perifocal_position_.at(0), 2) +
                 pow(perifocal_position_.at(1), 2));
   }
+  double get_radius_ECI() {
+    return sqrt(pow(ECI_position_.at(0), 2) +
+                pow(ECI_position_.at(1), 2) +
+                pow(ECI_position_.at(2),2));
+  }
   double get_total_energy() {
     double orbital_radius = get_radius();
     double gravitational_potential_energy =
         -G * mass_Earth * m_ / orbital_radius;
 
     double orbital_speed = get_speed();
-    double kinetic_energy = (1 / 2) * m_ * (orbital_speed * orbital_speed);
+    double kinetic_energy = (1.0 / 2.0) * m_ * (orbital_speed * orbital_speed);
 
     return (gravitational_potential_energy + kinetic_energy);
   }

--- a/src/Satellite.cpp
+++ b/src/Satellite.cpp
@@ -203,8 +203,8 @@ void Satellite::evolve_RK4(const double input_step_size) {
       {};
 
   for (const ThrustProfileLVLH thrust_profile : thrust_profile_list_) {
-    if (((t_ + (input_step_size / 2)) >= thrust_profile.t_start_) &&
-        ((t_ + (input_step_size / 2)) <= thrust_profile.t_end_)) {
+    if (((t_ + (input_step_size / 2.0)) >= thrust_profile.t_start_) &&
+        ((t_ + (input_step_size / 2.0)) <= thrust_profile.t_end_)) {
       list_of_LVLH_forces_at_half_timestep_past.push_back(
           thrust_profile.LVLH_force_vec_);
       std::array<double, 3> ECI_thrust_vector = convert_LVLH_to_ECI_manual(
@@ -555,6 +555,8 @@ double Satellite::get_orbital_element(const std::string orbital_element_name) {
     return orbital_rate_;
   } else if (orbital_element_name == "Orbital Angular Acceleration") {
     return orbital_angular_acceleration_;
+  } else if (orbital_element_name == "Total Energy") {
+    return get_total_energy();
   } else {
     std::cout << "Unrecognized argument, returning -1";
     return -1;

--- a/tests/circular_orbit_tests.cpp
+++ b/tests/circular_orbit_tests.cpp
@@ -19,7 +19,7 @@ const double tolerance = pow(10.0, -12);
 // locally than when run on Github actions workflow
 const double length_tolerance = pow(10.0, -7);
 const double epsilon = pow(10.0, -7);
-const double energy_cons_tolerance = pow(10.0, -5);
+const double energy_cons_relative_tolerance = pow(10.0, -5);
 
 TEST(CircularOrbitTests, OrbitalSpeed1) {
   Satellite test_satellite("../tests/circular_orbit_test_1_input.json");
@@ -51,16 +51,16 @@ TEST(CircularOrbitTests, TotalEnergyTimestep1) {
   Satellite test_satellite("../tests/circular_orbit_test_2_input.json");
   double initial_energy = test_satellite.get_total_energy();
   double test_timestep = 1;  // s
-  bool perturbation_bool = false;
+  bool perturbation_bool = true;
   std::pair<double, int> new_timestep_and_error_code =
       test_satellite.evolve_RK45(epsilon, test_timestep, perturbation_bool);
   double next_timestep = new_timestep_and_error_code.first;
   int error_code = new_timestep_and_error_code.second;
   double evolved_energy = test_satellite.get_total_energy();
 
-  EXPECT_TRUE(abs(initial_energy - evolved_energy) < energy_cons_tolerance)
-      << "Total energy not preserved within tolerance. Difference: "
-      << initial_energy - evolved_energy << "\n";
+  EXPECT_TRUE(abs(initial_energy - evolved_energy)/initial_energy < energy_cons_relative_tolerance)
+      << "Total energy not preserved within relative tolerance. Relative difference: "
+      << abs(initial_energy - evolved_energy)/initial_energy << "\n";
 }
 
 TEST(CircularOrbitTests, EvolvedOrbitalRadius1) {

--- a/tests/elliptical_orbit_test_3.json
+++ b/tests/elliptical_orbit_test_3.json
@@ -1,0 +1,10 @@
+{
+  "Inclination": 23.2,
+  "RAAN": 50,
+  "Argument of Periapsis": 29,
+  "Eccentricity": 0.2,
+  "Semimajor Axis": 11035,
+  "True Anomaly": 180,
+  "Mass": 930,
+  "Name": "Elliptical_Test_3"
+}

--- a/tests/elliptical_orbit_tests.cpp
+++ b/tests/elliptical_orbit_tests.cpp
@@ -179,7 +179,7 @@ TEST(EllipticalOrbitTests,OrbitalSpeedCalcs1) {
   double orbital_speed_perifocal=test_satellite.get_speed();
   double orbital_speed_ECI=test_satellite.get_speed_ECI();
   EXPECT_TRUE(abs(orbital_speed_ECI - orbital_speed_perifocal) < tolerance)
-      << "Difference between orbital radii calculated with "
+      << "Difference between orbital speeds calculated with "
       " perifocal and ECI coordinates: "
       << orbital_speed_ECI - orbital_speed_perifocal <<"\n";
 }


### PR DESCRIPTION
# Context
I wanted to add some more orbital tests, initially was mostly interested in adding more energy conservation tests. Along the way, noticed an issue in kinetic energy calculation.

# Changes
- Fixed bug where kinetic energy was always calculated to be 0 because of (1/2) factor (not using an explicit non-integer for numerator and/or denominator)
- Added some energy conservation tests (using a relative tolerance)
    - Made circular orbit energy test use relative tolerance as well to be consistent
- Added some tests to make sure orbital radius and orbital speed calculated with perifocal coordinates matched expectations from ECI coordinates
- Renaming semimajor_axis_tolerance to length_tolerance because it's now also being used for orbital radius comparison test
- Made numerical factors in various other divisions to be explicitly non-integers to avoid any possible unintended behavior in that regard
- Added total energy as accessible output for plotting to be able to track energy over time

# Integration Tests
Needs to pass existing tests, and new tests need to pass