### PR TITLE
Adding optional toggle for including effect of (simple model of) atmospheric drag

### DIFF
--- a/include/Satellite.h
+++ b/include/Satellite.h
@@ -6,8 +6,6 @@
 #include <nlohmann/json.hpp>
 #include <stdexcept>
 
-using json = nlohmann::json;
-
 // Define constants
 const double G =
     6.674 *
@@ -16,6 +14,8 @@ const double mass_Earth =
     5.9722 * pow(10, 24);  // https://en.wikipedia.org/wiki/Earth_mass
 const double radius_Earth =
     6378137;  // https://en.wikipedia.org/wiki/Earth_radius
+    
+using json = nlohmann::json;
 
 class ThrustProfileLVLH {
   // Note: for now, thrust forces are assumed to act through center of mass of
@@ -106,6 +106,10 @@ class Satellite {
   double roll_angle_ = {0};
   double yaw_angle_ = {0};
 
+  // For atmospheric drag calculations
+  // Surface area of satellite assumed to face drag conditions
+  double A_s_ = {0};
+
   // body-frame angular velocities relative to the LVLH frame, represented in
   // the body frame
   std::array<double, 3> body_angular_velocity_vec_wrt_LVLH_in_body_frame_ = {
@@ -130,8 +134,9 @@ class Satellite {
   std::vector<std::array<double, 3>> list_of_ECI_forces_at_this_time_ = {};
   std::vector<std::array<double, 3>> list_of_body_frame_torques_at_this_time_ =
       {};
-  // std::vector<std::array<double,3>>
-  // list_of_body_frame_torques_at_this_time_={};
+
+  double drag_surface_area = {0}; // Surface area of satellite used for
+  // atmospheric drag calculations
 
   std::pair<double, double> calculate_eccentric_anomaly(
       const double input_eccentricity, const double input_true_anomaly,
@@ -202,9 +207,14 @@ class Satellite {
     m_ = input_data.at("Mass");
     name_ = input_data.at("Name");
 
-    // making plotting color an optional parameter
+    // Making plotting color an optional parameter
     if (input_data.find("Plotting Color") != input_data.end()) {
       plotting_color_ = input_data.at("Plotting Color");
+    }
+
+    // Making satellite surface area facing drag conditions an optional parameter
+    if (input_data.find("A_s") != input_data.end()) {
+      A_s_ = input_data.at("A_s");
     }
 
     t_ = 0;  // for now, assuming satellites are initialized at time t=0;
@@ -327,7 +337,9 @@ class Satellite {
 
   std::pair<double, int> evolve_RK45(const double input_epsilon,
                                      const double input_initial_timestep,
-                                     const bool perturbation = true);
+                                     const bool perturbation = true,
+                                     const bool atmospheric_drag = false,
+                                     std::pair<double,double> drag_elements = {});
 
   double get_orbital_element(const std::string orbital_element_name);
   double calculate_instantaneous_orbit_rate();

--- a/include/Satellite.h
+++ b/include/Satellite.h
@@ -14,7 +14,7 @@ const double mass_Earth =
     5.9722 * pow(10, 24);  // https://en.wikipedia.org/wiki/Earth_mass
 const double radius_Earth =
     6378137;  // https://en.wikipedia.org/wiki/Earth_radius
-    
+
 using json = nlohmann::json;
 
 class ThrustProfileLVLH {
@@ -42,8 +42,11 @@ class ThrustProfileLVLH {
     }
   }
 
-  bool operator == (const ThrustProfileLVLH& input_profile){
-    return ((t_start_ == input_profile.t_start_) && (t_end_ == input_profile.t_end_) && (std::equal(LVLH_force_vec_.begin(), LVLH_force_vec_.end(),input_profile.LVLH_force_vec_.begin())));
+  bool operator==(const ThrustProfileLVLH& input_profile) {
+    return ((t_start_ == input_profile.t_start_) &&
+            (t_end_ == input_profile.t_end_) &&
+            (std::equal(LVLH_force_vec_.begin(), LVLH_force_vec_.end(),
+                        input_profile.LVLH_force_vec_.begin())));
   }
 };
 
@@ -69,8 +72,12 @@ class BodyframeTorqueProfile {
           input_torque_magnitude * bodyframe_normalized_torque_axis_vec.at(ind);
     }
   }
-  bool operator == (const BodyframeTorqueProfile& input_profile){
-    return ((t_start_ == input_profile.t_start_) && (t_end_ == input_profile.t_end_) && (std::equal(bodyframe_torque_list.begin(), bodyframe_torque_list.end(),input_profile.bodyframe_torque_list.begin())));
+  bool operator==(const BodyframeTorqueProfile& input_profile) {
+    return (
+        (t_start_ == input_profile.t_start_) &&
+        (t_end_ == input_profile.t_end_) &&
+        (std::equal(bodyframe_torque_list.begin(), bodyframe_torque_list.end(),
+                    input_profile.bodyframe_torque_list.begin())));
   }
 };
 
@@ -135,7 +142,7 @@ class Satellite {
   std::vector<std::array<double, 3>> list_of_body_frame_torques_at_this_time_ =
       {};
 
-  double drag_surface_area = {0}; // Surface area of satellite used for
+  double drag_surface_area = {0};  // Surface area of satellite used for
   // atmospheric drag calculations
 
   std::pair<double, double> calculate_eccentric_anomaly(
@@ -212,7 +219,8 @@ class Satellite {
       plotting_color_ = input_data.at("Plotting Color");
     }
 
-    // Making satellite surface area facing drag conditions an optional parameter
+    // Making satellite surface area facing drag conditions an optional
+    // parameter
     if (input_data.find("A_s") != input_data.end()) {
       A_s_ = input_data.at("A_s");
     }
@@ -267,9 +275,8 @@ class Satellite {
                 pow(perifocal_velocity_.at(1), 2));
   }
   double get_speed_ECI() {
-    return sqrt(pow(ECI_velocity_.at(0), 2) +
-                pow(ECI_velocity_.at(1), 2) +
-                pow(ECI_velocity_.at(2),2));
+    return sqrt(pow(ECI_velocity_.at(0), 2) + pow(ECI_velocity_.at(1), 2) +
+                pow(ECI_velocity_.at(2), 2));
   }
   double get_radius() {
     // shouldn't matter which frame I use, might as well use perifocal coords
@@ -279,9 +286,8 @@ class Satellite {
                 pow(perifocal_position_.at(1), 2));
   }
   double get_radius_ECI() {
-    return sqrt(pow(ECI_position_.at(0), 2) +
-                pow(ECI_position_.at(1), 2) +
-                pow(ECI_position_.at(2),2));
+    return sqrt(pow(ECI_position_.at(0), 2) + pow(ECI_position_.at(1), 2) +
+                pow(ECI_position_.at(2), 2));
   }
   double get_total_energy() {
     double orbital_radius = get_radius();
@@ -335,11 +341,10 @@ class Satellite {
   int update_orbital_elements_from_position_and_velocity();
   std::array<double, 6> get_orbital_elements();
 
-  std::pair<double, int> evolve_RK45(const double input_epsilon,
-                                     const double input_initial_timestep,
-                                     const bool perturbation = true,
-                                     const bool atmospheric_drag = false,
-                                     std::pair<double,double> drag_elements = {});
+  std::pair<double, int> evolve_RK45(
+      const double input_epsilon, const double input_initial_timestep,
+      const bool perturbation = true, const bool atmospheric_drag = false,
+      std::pair<double, double> drag_elements = {});
 
   double get_orbital_element(const std::string orbital_element_name);
   double calculate_instantaneous_orbit_rate();
@@ -349,7 +354,6 @@ class Satellite {
                                                 const double yaw_angle);
   double get_attitude_val(const std::string input_attitude_val_name);
   double calculate_orbital_period();
-
 };
 
 #endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -12,22 +12,20 @@ using Eigen::MatrixXd;
 using Eigen::Vector3d;
 using Eigen::Vector4d;
 
-
-
 std::array<double, 3> calculate_orbital_acceleration(
     const std::array<double, 3> input_r_vec, const double input_spacecraft_mass,
     const std::vector<std::array<double, 3>> input_vec_of_force_vectors_in_ECI =
         {});
 std::array<double, 3> calculate_orbital_acceleration(
-  const std::array<double, 3> input_r_vec, const double input_spacecraft_mass,
-  const std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,
-  const double input_evaluation_time,
-  const std::array<double, 3> input_velocity_vec,
-  const double input_inclination, const double input_arg_of_periapsis,
-  const double input_true_anomaly, const double input_F_10,
-  const double input_A_p, const double input_A_s,
-  const double input_satellite_mass, const bool perturbation, 
-  const bool atmospheric_drag);
+    const std::array<double, 3> input_r_vec, const double input_spacecraft_mass,
+    const std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,
+    const double input_evaluation_time,
+    const std::array<double, 3> input_velocity_vec,
+    const double input_inclination, const double input_arg_of_periapsis,
+    const double input_true_anomaly, const double input_F_10,
+    const double input_A_p, const double input_A_s,
+    const double input_satellite_mass, const bool perturbation,
+    const bool atmospheric_drag);
 
 std::array<double, 6> RK4_deriv_function_orbit_position_and_velocity(
     const std::array<double, 6> input_position_and_velocity,
@@ -98,13 +96,11 @@ std::array<double, T> RK4_step(
   return y_nplus1;
 }
 
-void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,
-                                const double input_timestep,
-                                const double input_total_sim_time,
-                                const double input_epsilon,
-                                const bool perturbation = true,
-                                const bool atmospheric_drag = false,
-                                const std::pair<double,double> drag_elements = {});
+void sim_and_draw_orbit_gnuplot(
+    std::vector<Satellite> input_satellite_vector, const double input_timestep,
+    const double input_total_sim_time, const double input_epsilon,
+    const bool perturbation = true, const bool atmospheric_drag = false,
+    const std::pair<double, double> drag_elements = {});
 
 template <int T>
 std::pair<std::array<double, T>, std::pair<double, double>> RK45_step(
@@ -233,14 +229,14 @@ std::array<double, 3> convert_ECI_to_LVLH_manual(
     const std::array<double, 3> input_position_vec,
     const std::array<double, 3> input_velocity_vec);
 std::array<double, 6> RK45_deriv_function_orbit_position_and_velocity(
-  const std::array<double, 6> input_position_and_velocity,
-  const double input_spacecraft_mass,
-  const std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,
-  const double input_evaluation_time, const double input_inclination,
-  const double input_arg_of_periapsis, const double input_true_anomaly,
-  const double input_F_10, const double input_A_p, const double input_A_s,
-  const double input_satellite_mass, const bool perturbation, 
-  const bool atmospheric_drag);
+    const std::array<double, 6> input_position_and_velocity,
+    const double input_spacecraft_mass,
+    const std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,
+    const double input_evaluation_time, const double input_inclination,
+    const double input_arg_of_periapsis, const double input_true_anomaly,
+    const double input_F_10, const double input_A_p, const double input_A_s,
+    const double input_satellite_mass, const bool perturbation,
+    const bool atmospheric_drag);
 
 std::array<double, 3> convert_cylindrical_to_cartesian(
     const double input_r_comp, const double input_theta_comp,
@@ -249,15 +245,14 @@ void sim_and_plot_orbital_elem_gnuplot(
     std::vector<Satellite> input_satellite_vector, const double input_timestep,
     const double input_total_sim_time, const double input_epsilon,
     const std::string input_orbital_element_name,
-    const bool perturbation = true,
-    const bool atmospheric_drag = false,
-    const std::pair<double,double> drag_elements = {});
+    const bool perturbation = true, const bool atmospheric_drag = false,
+    const std::pair<double, double> drag_elements = {});
 void sim_and_plot_attitude_evolution_gnuplot(
     std::vector<Satellite> input_satellite_vector, const double input_timestep,
     const double input_total_sim_time, const double input_epsilon,
     const std::string input_plotted_val_name, const bool perturbation = true,
-    const bool atmospheric_drag = false, 
-    const std::pair<double,double> drag_elements = {});
+    const bool atmospheric_drag = false,
+    const std::pair<double, double> drag_elements = {});
 
 Matrix3d rollyawpitch_bodyframe_to_LVLH(
     const std::array<double, 3> input_bodyframe_vec, const double input_roll,
@@ -309,8 +304,8 @@ std::pair<std::array<double, T>, std::pair<double, double>> RK45_step(
         const std::vector<BodyframeTorqueProfile>, const Vector3d, const double,
         const Matrix3d, const Vector3d, const double,
         const std::vector<ThrustProfileLVLH>, const double, const double,
-        const double, const double, const double,
-        const double, const double, const bool, const bool)>
+        const double, const double, const double, const double, const double,
+        const bool, const bool)>
         input_combined_derivative_function,
     const Matrix3d J_matrix,
     const std::vector<BodyframeTorqueProfile>
@@ -321,10 +316,10 @@ std::pair<std::array<double, T>, std::pair<double, double>> RK45_step(
     const double input_spacecraft_mass,
     const std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,
     const double input_inclination, const double input_arg_of_periapsis,
-    const double input_true_anomaly, const double input_F_10, 
-    const double input_A_p, const double input_A_s,
-    const bool perturbation, const double atmospheric_drag, 
-    const double input_t_n, const double input_epsilon) {
+    const double input_true_anomaly, const double input_F_10,
+    const double input_A_p, const double input_A_s, const bool perturbation,
+    const double atmospheric_drag, const double input_t_n,
+    const double input_epsilon) {
   // Version for combined satellite orbital motion and attitude time evolution
   // Implementing RK4(5) method for its adaptive step size
   // Refs:https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta%E2%80%93Fehlberg_method
@@ -429,16 +424,15 @@ std::pair<std::array<double, T>, std::pair<double, double>> RK45_step(
     output_pair.second = output_timestep_pair;
     return output_pair;
   } else {
-    return RK45_step<T>(y_n, h_new, input_combined_derivative_function,
-                        J_matrix, input_bodyframe_torque_profile_list,
-                        input_omega_I, input_orbital_angular_acceleration,
-                        input_LVLH_to_bodyframe_transformation_matrix,
-                        input_omega_LVLH_wrt_inertial_in_LVLH,
-                        input_spacecraft_mass,
-                        input_list_of_thrust_profiles_LVLH, input_inclination,
-                        input_arg_of_periapsis, input_true_anomaly,
-                        input_F_10, input_A_p, input_A_s, perturbation, 
-                        atmospheric_drag, input_t_n, input_epsilon);
+    return RK45_step<T>(
+        y_n, h_new, input_combined_derivative_function, J_matrix,
+        input_bodyframe_torque_profile_list, input_omega_I,
+        input_orbital_angular_acceleration,
+        input_LVLH_to_bodyframe_transformation_matrix,
+        input_omega_LVLH_wrt_inertial_in_LVLH, input_spacecraft_mass,
+        input_list_of_thrust_profiles_LVLH, input_inclination,
+        input_arg_of_periapsis, input_true_anomaly, input_F_10, input_A_p,
+        input_A_s, perturbation, atmospheric_drag, input_t_n, input_epsilon);
   }
 }
 Vector3d calculate_omega_I(

--- a/include/utils.h
+++ b/include/utils.h
@@ -12,17 +12,22 @@ using Eigen::MatrixXd;
 using Eigen::Vector3d;
 using Eigen::Vector4d;
 
+
+
 std::array<double, 3> calculate_orbital_acceleration(
     const std::array<double, 3> input_r_vec, const double input_spacecraft_mass,
     const std::vector<std::array<double, 3>> input_vec_of_force_vectors_in_ECI =
         {});
 std::array<double, 3> calculate_orbital_acceleration(
-    const std::array<double, 3> input_r_vec, const double input_spacecraft_mass,
-    const std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,
-    const double input_evaluation_time,
-    const std::array<double, 3> input_velocity_vec,
-    const double input_inclination, const double input_arg_of_periapsis,
-    const double input_true_anomaly, const bool perturbation);
+  const std::array<double, 3> input_r_vec, const double input_spacecraft_mass,
+  const std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,
+  const double input_evaluation_time,
+  const std::array<double, 3> input_velocity_vec,
+  const double input_inclination, const double input_arg_of_periapsis,
+  const double input_true_anomaly, const double input_F_10,
+  const double input_A_p, const double input_A_s,
+  const double input_satellite_mass, const bool perturbation, 
+  const bool atmospheric_drag);
 
 std::array<double, 6> RK4_deriv_function_orbit_position_and_velocity(
     const std::array<double, 6> input_position_and_velocity,
@@ -97,7 +102,9 @@ void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,
                                 const double input_timestep,
                                 const double input_total_sim_time,
                                 const double input_epsilon,
-                                const bool perturbation = true);
+                                const bool perturbation = true,
+                                const bool atmospheric_drag = false,
+                                const std::pair<double,double> drag_elements = {});
 
 template <int T>
 std::pair<std::array<double, T>, std::pair<double, double>> RK45_step(
@@ -226,12 +233,14 @@ std::array<double, 3> convert_ECI_to_LVLH_manual(
     const std::array<double, 3> input_position_vec,
     const std::array<double, 3> input_velocity_vec);
 std::array<double, 6> RK45_deriv_function_orbit_position_and_velocity(
-    const std::array<double, 6> input_position_and_velocity,
-    const double input_spacecraft_mass,
-    const std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,
-    const double input_evaluation_time, const double input_inclination,
-    const double input_arg_of_periapsis, const double input_true_anomaly,
-    const bool perturbation);
+  const std::array<double, 6> input_position_and_velocity,
+  const double input_spacecraft_mass,
+  const std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,
+  const double input_evaluation_time, const double input_inclination,
+  const double input_arg_of_periapsis, const double input_true_anomaly,
+  const double input_F_10, const double input_A_p, const double input_A_s,
+  const double input_satellite_mass, const bool perturbation, 
+  const bool atmospheric_drag);
 
 std::array<double, 3> convert_cylindrical_to_cartesian(
     const double input_r_comp, const double input_theta_comp,
@@ -240,11 +249,15 @@ void sim_and_plot_orbital_elem_gnuplot(
     std::vector<Satellite> input_satellite_vector, const double input_timestep,
     const double input_total_sim_time, const double input_epsilon,
     const std::string input_orbital_element_name,
-    const bool perturbation = true);
+    const bool perturbation = true,
+    const bool atmospheric_drag = false,
+    const std::pair<double,double> drag_elements = {});
 void sim_and_plot_attitude_evolution_gnuplot(
     std::vector<Satellite> input_satellite_vector, const double input_timestep,
     const double input_total_sim_time, const double input_epsilon,
-    const std::string input_plotted_val_name, const bool perturbation = true);
+    const std::string input_plotted_val_name, const bool perturbation = true,
+    const bool atmospheric_drag = false, 
+    const std::pair<double,double> drag_elements = {});
 
 Matrix3d rollyawpitch_bodyframe_to_LVLH(
     const std::array<double, 3> input_bodyframe_vec, const double input_roll,
@@ -285,7 +298,8 @@ RK45_combined_orbit_position_velocity_attitude_deriv_function(
     const std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,
     const double input_evaluation_time, const double input_inclination,
     const double input_arg_of_periapsis, const double input_true_anomaly,
-    const bool perturbation);
+    const double input_F_10, const double input_A_p, const double input_A_s,
+    const bool perturbation, const bool atmospheric_drag);
 
 template <int T>
 std::pair<std::array<double, T>, std::pair<double, double>> RK45_step(
@@ -295,7 +309,8 @@ std::pair<std::array<double, T>, std::pair<double, double>> RK45_step(
         const std::vector<BodyframeTorqueProfile>, const Vector3d, const double,
         const Matrix3d, const Vector3d, const double,
         const std::vector<ThrustProfileLVLH>, const double, const double,
-        const double, const double, const bool)>
+        const double, const double, const double,
+        const double, const double, const bool, const bool)>
         input_combined_derivative_function,
     const Matrix3d J_matrix,
     const std::vector<BodyframeTorqueProfile>
@@ -306,7 +321,9 @@ std::pair<std::array<double, T>, std::pair<double, double>> RK45_step(
     const double input_spacecraft_mass,
     const std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,
     const double input_inclination, const double input_arg_of_periapsis,
-    const double input_true_anomaly, const bool perturbation,
+    const double input_true_anomaly, const double input_F_10, 
+    const double input_A_p, const double input_A_s,
+    const bool perturbation, const double atmospheric_drag, 
     const double input_t_n, const double input_epsilon) {
   // Version for combined satellite orbital motion and attitude time evolution
   // Implementing RK4(5) method for its adaptive step size
@@ -361,7 +378,7 @@ std::pair<std::array<double, T>, std::pair<double, double>> RK45_step(
             input_omega_LVLH_wrt_inertial_in_LVLH, input_spacecraft_mass,
             input_list_of_thrust_profiles_LVLH, evaluation_time,
             input_inclination, input_arg_of_periapsis, input_true_anomaly,
-            perturbation);
+            input_F_10, input_A_p, input_A_s, perturbation, atmospheric_drag);
     for (size_t y_val_ind = 0; y_val_ind < y_n.size(); y_val_ind++) {
       k_vec_at_this_s.at(y_val_ind) =
           input_step_size * derivative_function_output.at(y_val_ind);
@@ -420,7 +437,8 @@ std::pair<std::array<double, T>, std::pair<double, double>> RK45_step(
                         input_spacecraft_mass,
                         input_list_of_thrust_profiles_LVLH, input_inclination,
                         input_arg_of_periapsis, input_true_anomaly,
-                        perturbation, input_t_n, input_epsilon);
+                        input_F_10, input_A_p, input_A_s, perturbation, 
+                        atmospheric_drag, input_t_n, input_epsilon);
   }
 }
 Vector3d calculate_omega_I(

--- a/input_8.json
+++ b/input_8.json
@@ -1,0 +1,15 @@
+{
+  "Inclination": 20,
+  "RAAN": 0,
+  "Argument of Periapsis": 20,
+  "Eccentricity": 0.2,
+  "Semimajor Axis": 6700,
+  "True Anomaly": 0,
+  "Mass": 100,
+  "Name": "Satellite 8",
+  "Plotting Color": "dark-goldenrod",
+  "Initial Roll Angle": 0,
+  "Initial omega_y": 0,
+  "A_s": 10
+
+}

--- a/input_9.json
+++ b/input_9.json
@@ -1,0 +1,15 @@
+{
+  "Inclination": 20,
+  "RAAN": 0,
+  "Argument of Periapsis": 20,
+  "Eccentricity": 0.2,
+  "Semimajor Axis": 6700,
+  "True Anomaly": 0,
+  "Mass": 100,
+  "Name": "Satellite 9",
+  "Plotting Color": "forest-green",
+  "Initial Roll Angle": 0,
+  "Initial omega_y": 0,
+  "A_s": 0
+
+}

--- a/src/Satellite.cpp
+++ b/src/Satellite.cpp
@@ -416,11 +416,10 @@ std::array<double, 6> Satellite::get_orbital_elements() {
   return orbit_elems_array;
 }
 
-std::pair<double, int> Satellite::evolve_RK45(const double input_epsilon,
-                                              const double input_step_size,
-                                              const bool perturbation,
-                                              const bool atmospheric_drag,
-                                              const std::pair<double,double> drag_elements) {
+std::pair<double, int> Satellite::evolve_RK45(
+    const double input_epsilon, const double input_step_size,
+    const bool perturbation, const bool atmospheric_drag,
+    const std::pair<double, double> drag_elements) {
   // perturbation is a flag which, when set to true, currently accounts for J2
   // perturbation.
 
@@ -487,9 +486,8 @@ std::pair<double, int> Satellite::evolve_RK45(const double input_epsilon,
           J_matrix, bodyframe_torque_profile_list_, omega_I,
           orbital_angular_acceleration_, LVLH_to_body_transformation_matrix,
           omega_LVLH_wrt_inertial_in_LVLH, m_, thrust_profile_list_,
-          inclination_, arg_of_periapsis_, true_anomaly_, input_F_10, 
-          input_A_p, A_s_,perturbation, atmospheric_drag,
-          t_,input_epsilon);
+          inclination_, arg_of_periapsis_, true_anomaly_, input_F_10, input_A_p,
+          A_s_, perturbation, atmospheric_drag, t_, input_epsilon);
 
   std::array<double, 13>
       output_combined_position_velocity_quaternion_angular_velocity_array =

--- a/src/Satellite.cpp
+++ b/src/Satellite.cpp
@@ -418,7 +418,9 @@ std::array<double, 6> Satellite::get_orbital_elements() {
 
 std::pair<double, int> Satellite::evolve_RK45(const double input_epsilon,
                                               const double input_step_size,
-                                              const bool perturbation) {
+                                              const bool perturbation,
+                                              const bool atmospheric_drag,
+                                              const std::pair<double,double> drag_elements) {
   // perturbation is a flag which, when set to true, currently accounts for J2
   // perturbation.
 
@@ -430,6 +432,13 @@ std::pair<double, int> Satellite::evolve_RK45(const double input_epsilon,
   //  body frame with respect to the LVLH frame, and omega_i is the angular
   //  velocity around the ith axis of the body frame with respect to the LVLH
   //  frame, represented in the body frame
+
+  // The tuple drag_elements contains the F_10 value and the A_p value used for
+  // atmospheric drag calculations, if applicable
+  // F_10 is the first element, A_p is the second element
+  double input_F_10 = drag_elements.first;
+  double input_A_p = drag_elements.second;
+
   std::array<double, 13>
       combined_initial_position_velocity_quaternion_angular_velocity_array = {};
   std::pair<std::array<double, 3>, std::array<double, 3>>
@@ -478,8 +487,9 @@ std::pair<double, int> Satellite::evolve_RK45(const double input_epsilon,
           J_matrix, bodyframe_torque_profile_list_, omega_I,
           orbital_angular_acceleration_, LVLH_to_body_transformation_matrix,
           omega_LVLH_wrt_inertial_in_LVLH, m_, thrust_profile_list_,
-          inclination_, arg_of_periapsis_, true_anomaly_, perturbation, t_,
-          input_epsilon);
+          inclination_, arg_of_periapsis_, true_anomaly_, input_F_10, 
+          input_A_p, A_s_,perturbation, atmospheric_drag,
+          t_,input_epsilon);
 
   std::array<double, 13>
       output_combined_position_velocity_quaternion_angular_velocity_array =

--- a/src/simulation_setup.cpp
+++ b/src/simulation_setup.cpp
@@ -30,7 +30,7 @@ int main() {
 
   double timestep = 2;
   double total_sim_time = 25000;
-  double epsilon = pow(10, -12);
+  double epsilon = pow(10, -14);
   sim_and_draw_orbit_gnuplot(satellite_vector_1, timestep, total_sim_time,
                              epsilon);
 
@@ -44,7 +44,7 @@ int main() {
   total_sim_time = 9952;
   sim_and_plot_orbital_elem_gnuplot(satellite_vector_2, timestep,
                                     total_sim_time, epsilon,
-                                    "Argument of Periapsis");
+                                    "Argument of Periapsis",true);
   Satellite test_sat_7("../input_7.json");
   std::array<double, 3> torque_direction = {0, -1, 0};
   double torque_magnitude = 0.0005;  // N
@@ -57,5 +57,23 @@ int main() {
   sim_and_plot_attitude_evolution_gnuplot(
       satellite_vector_3, timestep, total_sim_time, epsilon, "Pitch", false);
 
+  //Now let's demonstrate effect of atmospheric drag approximation
+  Satellite test_sat_8("../input_8.json");
+  Satellite test_sat_9("../input_9.json");
+  std::vector<Satellite> satellite_vector_4 = {test_sat_8,test_sat_9};
+
+  // Drag parameters
+  double F_10 = 100; // Solar radio ten centimeter flux
+  double A_p = 120; // Geomagnetic A_p index
+  
+  // Collect drag parameters into a tuple with F_10 first and A_p second
+  std::pair<double,double> drag_elements = {F_10, A_p};
+  total_sim_time = 10000;
+  sim_and_plot_orbital_elem_gnuplot(satellite_vector_4, timestep,
+    total_sim_time, epsilon,
+    "Eccentricity",false, true, drag_elements);
+  sim_and_plot_orbital_elem_gnuplot(satellite_vector_4, timestep,
+                                    total_sim_time, epsilon,
+                                    "Semimajor Axis",false, true, drag_elements);
   return 0;
 }

--- a/src/simulation_setup.cpp
+++ b/src/simulation_setup.cpp
@@ -44,7 +44,7 @@ int main() {
   total_sim_time = 9952;
   sim_and_plot_orbital_elem_gnuplot(satellite_vector_2, timestep,
                                     total_sim_time, epsilon,
-                                    "Argument of Periapsis",true);
+                                    "Argument of Periapsis", true);
   Satellite test_sat_7("../input_7.json");
   std::array<double, 3> torque_direction = {0, -1, 0};
   double torque_magnitude = 0.0005;  // N
@@ -57,23 +57,23 @@ int main() {
   sim_and_plot_attitude_evolution_gnuplot(
       satellite_vector_3, timestep, total_sim_time, epsilon, "Pitch", false);
 
-  //Now let's demonstrate effect of atmospheric drag approximation
+  // Now let's demonstrate effect of atmospheric drag approximation
   Satellite test_sat_8("../input_8.json");
   Satellite test_sat_9("../input_9.json");
-  std::vector<Satellite> satellite_vector_4 = {test_sat_8,test_sat_9};
+  std::vector<Satellite> satellite_vector_4 = {test_sat_8, test_sat_9};
 
   // Drag parameters
-  double F_10 = 100; // Solar radio ten centimeter flux
-  double A_p = 120; // Geomagnetic A_p index
-  
+  double F_10 = 100;  // Solar radio ten centimeter flux
+  double A_p = 120;   // Geomagnetic A_p index
+
   // Collect drag parameters into a tuple with F_10 first and A_p second
-  std::pair<double,double> drag_elements = {F_10, A_p};
+  std::pair<double, double> drag_elements = {F_10, A_p};
   total_sim_time = 10000;
   sim_and_plot_orbital_elem_gnuplot(satellite_vector_4, timestep,
-    total_sim_time, epsilon,
-    "Eccentricity",false, true, drag_elements);
+                                    total_sim_time, epsilon, "Eccentricity",
+                                    false, true, drag_elements);
   sim_and_plot_orbital_elem_gnuplot(satellite_vector_4, timestep,
-                                    total_sim_time, epsilon,
-                                    "Semimajor Axis",false, true, drag_elements);
+                                    total_sim_time, epsilon, "Semimajor Axis",
+                                    false, true, drag_elements);
   return 0;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -314,13 +314,14 @@ std::array<double, 3> calculate_orbital_acceleration(
   double altitude = (distance - radius_Earth) / 1000;  // km
 
   if ((atmospheric_drag) && (altitude >= 140) && (altitude <= 400)) {
+    // Refs: https://angeo.copernicus.org/articles/39/397/2021/
+    // https://www.spaceacademy.net.au/watch/debris/atmosmod.htm
     double speed = sqrt(pow(input_velocity_vec.at(0), 2) +
                         pow(input_velocity_vec.at(1), 2) +
                         pow(input_velocity_vec.at(2), 2));
     // First, esimate atmospheric density
     double rho = {0};
     if (altitude < 180) {
-      // Ref: https://www.spaceacademy.net.au/watch/debris/atmosmod.htm
       double a0 = 7.001985 * pow(10, -2);
       double a1 = -4.336216 * pow(10, -3);
       double a2 = -5.009831 * pow(10, -3);
@@ -346,8 +347,7 @@ std::array<double, 3> calculate_orbital_acceleration(
     }
 
     // Now estimate the satellite's ballistic coefficient B
-    double C_d = 2.2;  // Ref:
-                       // https://angeo.copernicus.org/articles/39/397/2021/
+    double C_d = 2.2;
     double B = C_d * input_A_s / input_satellite_mass;
     double drag_deceleration = (1.0 / 2.0) * rho * B * pow(speed, 2);
     // Should act in direction directly opposite to velocity

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -319,7 +319,7 @@ std::array<double, 3> calculate_orbital_acceleration(
                         pow(input_velocity_vec.at(2), 2));
     // First, esimate atmospheric density
     double rho = {0};
-    if (distance < 180000) {
+    if (altitude < 180) {
       // Ref: https://www.spaceacademy.net.au/watch/debris/atmosmod.htm
       double a0 = 7.001985 * pow(10, -2);
       double a1 = -4.336216 * pow(10, -3);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -205,7 +205,10 @@ std::array<double, 3> calculate_orbital_acceleration(
     const double input_evaluation_time,
     const std::array<double, 3> input_velocity_vec,
     const double input_inclination, const double input_arg_of_periapsis,
-    const double input_true_anomaly, const bool perturbation) {
+    const double input_true_anomaly, const double input_F_10,
+    const double input_A_p, const double input_A_s,
+    const double input_satellite_mass, const bool perturbation, 
+    const bool atmospheric_drag) {
   // Note: this is the version used in the RK45 solver (this has a more updated
   // workflow) orbital acceleration = -G m_Earth/distance^3 * r_vec (just based
   // on rearranging F=ma with a the acceleration due to gravitational attraction
@@ -308,6 +311,51 @@ std::array<double, 3> calculate_orbital_acceleration(
       acceleration_vec.at(ind) += cartesian_acceleration_components.at(ind);
     }
   }
+  double altitude = (distance - radius_Earth)/1000; //km
+
+  if ((atmospheric_drag) && (altitude >= 140) && (altitude <= 400)){
+    double speed = sqrt(pow(input_velocity_vec.at(0),2) + pow(input_velocity_vec.at(1),2) + pow(input_velocity_vec.at(2),2));
+    // First, esimate atmospheric density
+    double rho = {0};
+    if (distance < 180000) {
+      //Ref: https://www.spaceacademy.net.au/watch/debris/atmosmod.htm
+      double a0 = 7.001985 * pow(10,-2);
+      double a1 = -4.336216 * pow(10,-3);
+      double a2 = -5.009831 * pow(10,-3);
+      double a3 = 1.621827 * pow(10,-4);
+      double a4 = -2.471283 * pow(10,-6);
+      double a5 = 1.904383 * pow(10,-8);
+      double a6 = -7.189421 * pow(10,-11);
+      double a7 = 1.060067 * pow(10, -13);
+      double fit_val = ((((((a7*altitude + a6)*altitude + a4)*altitude + a3)*altitude)+a2)*altitude + a1)*altitude + a0;
+      rho = pow(10,fit_val);
+    }
+    else {
+      double T = 900 + 2.5 * (input_F_10 - 70) + 1.5 * input_A_p;
+      double new_mu = 27 - 0.012 * (altitude - 200);
+      double H = T / new_mu;
+      rho = 6 * pow(10,-10) * exp(- (altitude - 175) / H);
+    }
+
+    // Now estimate the satellite's ballistic coefficient B
+    double C_d = 2.2; //Ref: https://angeo.copernicus.org/articles/39/397/2021/
+    double B = C_d * input_A_s / input_satellite_mass;
+    double drag_deceleration = (1.0/2.0) * rho * B * pow(speed,2);
+    //Should act in direction directly opposite to velocity
+    std::array<double,3> velocity_unit_vec = {0.0,0.0,0.0};
+    for (size_t ind=0;ind<3;ind++) {
+      velocity_unit_vec.at(ind) = input_velocity_vec.at(ind)/speed;
+    }
+    std::array<double,3> drag_acceleration_vec = {0.0,0.0,0.0};
+    for (size_t ind=0;ind<3;ind++) {
+      drag_acceleration_vec.at(ind) = drag_deceleration * (-1) * velocity_unit_vec.at(ind);
+      // Factor of (-1) because this acceleration acts in direction opposite to velocity
+    }
+    for (size_t ind = 0; ind < 3; ind++) {
+      acceleration_vec.at(ind) += drag_acceleration_vec.at(ind);
+
+    }
+  }
 
   return acceleration_vec;
 }
@@ -342,7 +390,9 @@ std::array<double, 6> RK45_deriv_function_orbit_position_and_velocity(
     const std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,
     const double input_evaluation_time, const double input_inclination,
     const double input_arg_of_periapsis, const double input_true_anomaly,
-    const bool perturbation) {
+    const double input_F_10, const double input_A_p, const double input_A_s,
+    const double input_satellite_mass, const bool perturbation, 
+    const bool atmospheric_drag) {
   std::array<double, 6> derivative_of_input_y = {};
   std::array<double, 3> position_array = {};
   std::array<double, 3> velocity_array = {};
@@ -358,7 +408,9 @@ std::array<double, 6> RK45_deriv_function_orbit_position_and_velocity(
                                      input_list_of_thrust_profiles_LVLH,
                                      input_evaluation_time, velocity_array,
                                      input_inclination, input_arg_of_periapsis,
-                                     input_true_anomaly, perturbation);
+                                     input_true_anomaly, input_F_10,
+                                     input_A_p, input_A_s,input_satellite_mass,
+                                     perturbation, atmospheric_drag);
 
   for (size_t ind = 3; ind < 6; ind++) {
     derivative_of_input_y.at(ind) = calculated_orbital_acceleration.at(ind - 3);
@@ -373,7 +425,9 @@ void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,
                                 const double input_timestep,
                                 const double input_total_sim_time,
                                 const double input_epsilon,
-                                const bool perturbation) {
+                                const bool perturbation,
+                                const bool atmospheric_drag,
+                                const std::pair<double,double> drag_elements) {
   if (input_satellite_vector.size() < 1) {
     std::cout << "No input Satellite objects\n";
     return;
@@ -485,7 +539,8 @@ void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,
       while (current_satellite_time < input_total_sim_time) {
         std::pair<double, int> new_timestep_and_error_code =
             current_satellite.evolve_RK45(input_epsilon, timestep_to_use,
-                                          perturbation);
+                                          perturbation, atmospheric_drag,
+                                          drag_elements);
         double new_timestep = new_timestep_and_error_code.first;
         int error_code = new_timestep_and_error_code.second;
         if (error_code != 0) {
@@ -520,7 +575,8 @@ void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,
 void sim_and_plot_orbital_elem_gnuplot(
     std::vector<Satellite> input_satellite_vector, const double input_timestep,
     const double input_total_sim_time, const double input_epsilon,
-    const std::string input_orbital_element_name, const bool perturbation) {
+    const std::string input_orbital_element_name, const bool perturbation,
+    const bool atmospheric_drag, const std::pair<double,double> drag_elements) {
   if (input_satellite_vector.size() < 1) {
     std::cout << "No input Satellite objects\n";
     return;
@@ -625,7 +681,7 @@ void sim_and_plot_orbital_elem_gnuplot(
       while (current_satellite_time < input_total_sim_time) {
         std::pair<double, int> new_timestep_and_error_code =
             current_satellite.evolve_RK45(input_epsilon, timestep_to_use,
-                                          perturbation);
+                                          perturbation, atmospheric_drag, drag_elements);
         double new_timestep = new_timestep_and_error_code.first;
         int error_code = new_timestep_and_error_code.second;
 
@@ -640,6 +696,8 @@ void sim_and_plot_orbital_elem_gnuplot(
         evolved_val =
             current_satellite.get_orbital_element(input_orbital_element_name);
         current_satellite_time = current_satellite.get_instantaneous_time();
+        // printf("%.17g %.17g\n", current_satellite_time,
+        //   evolved_val);
         fprintf(gnuplot_pipe, "%.17g %.17g\n", current_satellite_time,
                 evolved_val);
       }
@@ -713,7 +771,8 @@ std::array<double, 4> bodyframe_quaternion_deriv(
 void sim_and_plot_attitude_evolution_gnuplot(
     std::vector<Satellite> input_satellite_vector, const double input_timestep,
     const double input_total_sim_time, const double input_epsilon,
-    const std::string input_plotted_val_name, const bool perturbation) {
+    const std::string input_plotted_val_name, const bool perturbation,
+    const bool atmospheric_drag, const std::pair<double,double> drag_elements) {
   if (input_satellite_vector.size() < 1) {
     std::cout << "No input Satellite objects\n";
     return;
@@ -821,7 +880,8 @@ void sim_and_plot_attitude_evolution_gnuplot(
       while (current_satellite_time < input_total_sim_time) {
         std::pair<double, int> new_timestep_and_error_code =
             current_satellite.evolve_RK45(input_epsilon, timestep_to_use,
-                                          perturbation);
+                                          perturbation, atmospheric_drag,
+                                          drag_elements);
         double new_timestep = new_timestep_and_error_code.first;
         int error_code = new_timestep_and_error_code.second;
 
@@ -1068,19 +1128,20 @@ Matrix3d construct_J_matrix(const double input_Jxx, const double input_Jyy,
 
 std::array<double, 13>
 RK45_combined_orbit_position_velocity_attitude_deriv_function(
-    const std::array<double, 13>
-        combined_position_velocity_bodyframe_angular_array,
-    const Matrix3d J_matrix,
-    const std::vector<BodyframeTorqueProfile>
-        input_bodyframe_torque_profile_list,
-    const Vector3d input_omega_I, double input_orbital_angular_acceleration,
-    const Matrix3d input_LVLH_to_bodyframe_transformation_matrix,
-    const Vector3d input_omega_LVLH_wrt_inertial_in_LVLH,
-    const double input_spacecraft_mass,
-    const std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,
-    const double input_evaluation_time, const double input_inclination,
-    const double input_arg_of_periapsis, const double input_true_anomaly,
-    const bool perturbation) {
+  const std::array<double, 13>
+      combined_position_velocity_bodyframe_angular_array,
+  const Matrix3d J_matrix,
+  const std::vector<BodyframeTorqueProfile>
+      input_bodyframe_torque_profile_list,
+  const Vector3d input_omega_I, double input_orbital_angular_acceleration,
+  const Matrix3d input_LVLH_to_bodyframe_transformation_matrix,
+  const Vector3d input_omega_LVLH_wrt_inertial_in_LVLH,
+  const double input_spacecraft_mass,
+  const std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,
+  const double input_evaluation_time, const double input_inclination,
+  const double input_arg_of_periapsis, const double input_true_anomaly,
+  const double input_F_10, const double input_A_p, const double input_A_s,
+  const bool perturbation, const bool atmospheric_drag) {
   // Input vector is in the form of {ECI_position,
   // ECI_velocity,bodyframe_quaternion_to_LVLH,bodyframe_omega_wrt_LVLH}
   // Objective is to output derivative of that vector
@@ -1103,7 +1164,8 @@ RK45_combined_orbit_position_velocity_attitude_deriv_function(
           combined_position_and_velocity_array, input_spacecraft_mass,
           input_list_of_thrust_profiles_LVLH, input_evaluation_time,
           input_inclination, input_arg_of_periapsis, input_true_anomaly,
-          perturbation);
+          input_F_10, input_A_p, input_A_s, input_spacecraft_mass,
+          perturbation, atmospheric_drag);
 
   std::array<double, 7> angular_derivative_array =
       RK45_satellite_body_angular_deriv_function(

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -207,7 +207,7 @@ std::array<double, 3> calculate_orbital_acceleration(
     const double input_inclination, const double input_arg_of_periapsis,
     const double input_true_anomaly, const double input_F_10,
     const double input_A_p, const double input_A_s,
-    const double input_satellite_mass, const bool perturbation, 
+    const double input_satellite_mass, const bool perturbation,
     const bool atmospheric_drag) {
   // Note: this is the version used in the RK45 solver (this has a more updated
   // workflow) orbital acceleration = -G m_Earth/distance^3 * r_vec (just based
@@ -311,49 +311,59 @@ std::array<double, 3> calculate_orbital_acceleration(
       acceleration_vec.at(ind) += cartesian_acceleration_components.at(ind);
     }
   }
-  double altitude = (distance - radius_Earth)/1000; //km
+  double altitude = (distance - radius_Earth) / 1000;  // km
 
-  if ((atmospheric_drag) && (altitude >= 140) && (altitude <= 400)){
-    double speed = sqrt(pow(input_velocity_vec.at(0),2) + pow(input_velocity_vec.at(1),2) + pow(input_velocity_vec.at(2),2));
+  if ((atmospheric_drag) && (altitude >= 140) && (altitude <= 400)) {
+    double speed = sqrt(pow(input_velocity_vec.at(0), 2) +
+                        pow(input_velocity_vec.at(1), 2) +
+                        pow(input_velocity_vec.at(2), 2));
     // First, esimate atmospheric density
     double rho = {0};
     if (distance < 180000) {
-      //Ref: https://www.spaceacademy.net.au/watch/debris/atmosmod.htm
-      double a0 = 7.001985 * pow(10,-2);
-      double a1 = -4.336216 * pow(10,-3);
-      double a2 = -5.009831 * pow(10,-3);
-      double a3 = 1.621827 * pow(10,-4);
-      double a4 = -2.471283 * pow(10,-6);
-      double a5 = 1.904383 * pow(10,-8);
-      double a6 = -7.189421 * pow(10,-11);
+      // Ref: https://www.spaceacademy.net.au/watch/debris/atmosmod.htm
+      double a0 = 7.001985 * pow(10, -2);
+      double a1 = -4.336216 * pow(10, -3);
+      double a2 = -5.009831 * pow(10, -3);
+      double a3 = 1.621827 * pow(10, -4);
+      double a4 = -2.471283 * pow(10, -6);
+      double a5 = 1.904383 * pow(10, -8);
+      double a6 = -7.189421 * pow(10, -11);
       double a7 = 1.060067 * pow(10, -13);
-      double fit_val = ((((((a7*altitude + a6)*altitude + a4)*altitude + a3)*altitude)+a2)*altitude + a1)*altitude + a0;
-      rho = pow(10,fit_val);
-    }
-    else {
+      double fit_val =
+          ((((((a7 * altitude + a6) * altitude + a4) * altitude + a3) *
+             altitude) +
+            a2) *
+               altitude +
+           a1) *
+              altitude +
+          a0;
+      rho = pow(10, fit_val);
+    } else {
       double T = 900 + 2.5 * (input_F_10 - 70) + 1.5 * input_A_p;
       double new_mu = 27 - 0.012 * (altitude - 200);
       double H = T / new_mu;
-      rho = 6 * pow(10,-10) * exp(- (altitude - 175) / H);
+      rho = 6 * pow(10, -10) * exp(-(altitude - 175) / H);
     }
 
     // Now estimate the satellite's ballistic coefficient B
-    double C_d = 2.2; //Ref: https://angeo.copernicus.org/articles/39/397/2021/
+    double C_d = 2.2;  // Ref:
+                       // https://angeo.copernicus.org/articles/39/397/2021/
     double B = C_d * input_A_s / input_satellite_mass;
-    double drag_deceleration = (1.0/2.0) * rho * B * pow(speed,2);
-    //Should act in direction directly opposite to velocity
-    std::array<double,3> velocity_unit_vec = {0.0,0.0,0.0};
-    for (size_t ind=0;ind<3;ind++) {
-      velocity_unit_vec.at(ind) = input_velocity_vec.at(ind)/speed;
+    double drag_deceleration = (1.0 / 2.0) * rho * B * pow(speed, 2);
+    // Should act in direction directly opposite to velocity
+    std::array<double, 3> velocity_unit_vec = {0.0, 0.0, 0.0};
+    for (size_t ind = 0; ind < 3; ind++) {
+      velocity_unit_vec.at(ind) = input_velocity_vec.at(ind) / speed;
     }
-    std::array<double,3> drag_acceleration_vec = {0.0,0.0,0.0};
-    for (size_t ind=0;ind<3;ind++) {
-      drag_acceleration_vec.at(ind) = drag_deceleration * (-1) * velocity_unit_vec.at(ind);
-      // Factor of (-1) because this acceleration acts in direction opposite to velocity
+    std::array<double, 3> drag_acceleration_vec = {0.0, 0.0, 0.0};
+    for (size_t ind = 0; ind < 3; ind++) {
+      drag_acceleration_vec.at(ind) =
+          drag_deceleration * (-1) * velocity_unit_vec.at(ind);
+      // Factor of (-1) because this acceleration acts in direction opposite to
+      // velocity
     }
     for (size_t ind = 0; ind < 3; ind++) {
       acceleration_vec.at(ind) += drag_acceleration_vec.at(ind);
-
     }
   }
 
@@ -391,7 +401,7 @@ std::array<double, 6> RK45_deriv_function_orbit_position_and_velocity(
     const double input_evaluation_time, const double input_inclination,
     const double input_arg_of_periapsis, const double input_true_anomaly,
     const double input_F_10, const double input_A_p, const double input_A_s,
-    const double input_satellite_mass, const bool perturbation, 
+    const double input_satellite_mass, const bool perturbation,
     const bool atmospheric_drag) {
   std::array<double, 6> derivative_of_input_y = {};
   std::array<double, 3> position_array = {};
@@ -404,13 +414,12 @@ std::array<double, 6> RK45_deriv_function_orbit_position_and_velocity(
   }
 
   std::array<double, 3> calculated_orbital_acceleration =
-      calculate_orbital_acceleration(position_array, input_spacecraft_mass,
-                                     input_list_of_thrust_profiles_LVLH,
-                                     input_evaluation_time, velocity_array,
-                                     input_inclination, input_arg_of_periapsis,
-                                     input_true_anomaly, input_F_10,
-                                     input_A_p, input_A_s,input_satellite_mass,
-                                     perturbation, atmospheric_drag);
+      calculate_orbital_acceleration(
+          position_array, input_spacecraft_mass,
+          input_list_of_thrust_profiles_LVLH, input_evaluation_time,
+          velocity_array, input_inclination, input_arg_of_periapsis,
+          input_true_anomaly, input_F_10, input_A_p, input_A_s,
+          input_satellite_mass, perturbation, atmospheric_drag);
 
   for (size_t ind = 3; ind < 6; ind++) {
     derivative_of_input_y.at(ind) = calculated_orbital_acceleration.at(ind - 3);
@@ -427,7 +436,7 @@ void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,
                                 const double input_epsilon,
                                 const bool perturbation,
                                 const bool atmospheric_drag,
-                                const std::pair<double,double> drag_elements) {
+                                const std::pair<double, double> drag_elements) {
   if (input_satellite_vector.size() < 1) {
     std::cout << "No input Satellite objects\n";
     return;
@@ -576,7 +585,8 @@ void sim_and_plot_orbital_elem_gnuplot(
     std::vector<Satellite> input_satellite_vector, const double input_timestep,
     const double input_total_sim_time, const double input_epsilon,
     const std::string input_orbital_element_name, const bool perturbation,
-    const bool atmospheric_drag, const std::pair<double,double> drag_elements) {
+    const bool atmospheric_drag,
+    const std::pair<double, double> drag_elements) {
   if (input_satellite_vector.size() < 1) {
     std::cout << "No input Satellite objects\n";
     return;
@@ -681,7 +691,8 @@ void sim_and_plot_orbital_elem_gnuplot(
       while (current_satellite_time < input_total_sim_time) {
         std::pair<double, int> new_timestep_and_error_code =
             current_satellite.evolve_RK45(input_epsilon, timestep_to_use,
-                                          perturbation, atmospheric_drag, drag_elements);
+                                          perturbation, atmospheric_drag,
+                                          drag_elements);
         double new_timestep = new_timestep_and_error_code.first;
         int error_code = new_timestep_and_error_code.second;
 
@@ -772,7 +783,8 @@ void sim_and_plot_attitude_evolution_gnuplot(
     std::vector<Satellite> input_satellite_vector, const double input_timestep,
     const double input_total_sim_time, const double input_epsilon,
     const std::string input_plotted_val_name, const bool perturbation,
-    const bool atmospheric_drag, const std::pair<double,double> drag_elements) {
+    const bool atmospheric_drag,
+    const std::pair<double, double> drag_elements) {
   if (input_satellite_vector.size() < 1) {
     std::cout << "No input Satellite objects\n";
     return;
@@ -1128,20 +1140,20 @@ Matrix3d construct_J_matrix(const double input_Jxx, const double input_Jyy,
 
 std::array<double, 13>
 RK45_combined_orbit_position_velocity_attitude_deriv_function(
-  const std::array<double, 13>
-      combined_position_velocity_bodyframe_angular_array,
-  const Matrix3d J_matrix,
-  const std::vector<BodyframeTorqueProfile>
-      input_bodyframe_torque_profile_list,
-  const Vector3d input_omega_I, double input_orbital_angular_acceleration,
-  const Matrix3d input_LVLH_to_bodyframe_transformation_matrix,
-  const Vector3d input_omega_LVLH_wrt_inertial_in_LVLH,
-  const double input_spacecraft_mass,
-  const std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,
-  const double input_evaluation_time, const double input_inclination,
-  const double input_arg_of_periapsis, const double input_true_anomaly,
-  const double input_F_10, const double input_A_p, const double input_A_s,
-  const bool perturbation, const bool atmospheric_drag) {
+    const std::array<double, 13>
+        combined_position_velocity_bodyframe_angular_array,
+    const Matrix3d J_matrix,
+    const std::vector<BodyframeTorqueProfile>
+        input_bodyframe_torque_profile_list,
+    const Vector3d input_omega_I, double input_orbital_angular_acceleration,
+    const Matrix3d input_LVLH_to_bodyframe_transformation_matrix,
+    const Vector3d input_omega_LVLH_wrt_inertial_in_LVLH,
+    const double input_spacecraft_mass,
+    const std::vector<ThrustProfileLVLH> input_list_of_thrust_profiles_LVLH,
+    const double input_evaluation_time, const double input_inclination,
+    const double input_arg_of_periapsis, const double input_true_anomaly,
+    const double input_F_10, const double input_A_p, const double input_A_s,
+    const bool perturbation, const bool atmospheric_drag) {
   // Input vector is in the form of {ECI_position,
   // ECI_velocity,bodyframe_quaternion_to_LVLH,bodyframe_omega_wrt_LVLH}
   // Objective is to output derivative of that vector
@@ -1164,8 +1176,8 @@ RK45_combined_orbit_position_velocity_attitude_deriv_function(
           combined_position_and_velocity_array, input_spacecraft_mass,
           input_list_of_thrust_profiles_LVLH, input_evaluation_time,
           input_inclination, input_arg_of_periapsis, input_true_anomaly,
-          input_F_10, input_A_p, input_A_s, input_spacecraft_mass,
-          perturbation, atmospheric_drag);
+          input_F_10, input_A_p, input_A_s, input_spacecraft_mass, perturbation,
+          atmospheric_drag);
 
   std::array<double, 7> angular_derivative_array =
       RK45_satellite_body_angular_deriv_function(


### PR DESCRIPTION
# Context
Previously, the code did not account for atmospheric drag acting on satellites.

# Changes
- Added optional toggle to turn on effect of atmospheric drag using a simple model at low enough orbital altitudes
    - Constant C_d
    - Different approximations for atmospheric density depending on orbital altitude
    - Requires input F_10 (solar radio 10 centimeter flux) and geomagnetic A_p index

# Integration Tests
Needs to pass existing tests