### PR TITLE
Adding 3D plot example back in to simulation_setup, adding some progress indicators

### DIFF
--- a/input_3.json
+++ b/input_3.json
@@ -1,5 +1,5 @@
 {
-  "Inclination": 45,
+  "Inclination": 30,
   "RAAN": 1,
   "Argument of Periapsis": 10,
   "Eccentricity": 0.3,

--- a/simulation_setup.cpp
+++ b/simulation_setup.cpp
@@ -4,6 +4,9 @@
 #include "utils.h"
 
 int main() {
+  // This file demonstrates a few different ways you can run and
+  // visualize data from satellite simulations.
+
   // Initialize satellite object from an input JSON file
   Satellite test_sat_1("../input.json");
   // Define parameters for an LVLH frame thrust profile
@@ -31,8 +34,8 @@ int main() {
   double timestep = 2;
   double total_sim_time = 25000;
   double epsilon = pow(10, -12);
-  // sim_and_draw_orbit_gnuplot(satellite_vector_1, timestep, total_sim_time,
-  //                            epsilon);
+  sim_and_draw_orbit_gnuplot(satellite_vector_1, timestep, total_sim_time,
+                             epsilon);
 
   // Now some demonstrations of plotting orbital parameters
   Satellite test_sat_4("../input_4.json");

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -489,6 +489,7 @@ void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,
             "notitle with pm3d fillcolor rgbcolor 'navy'\n");
 
     // now the orbit data, inline, one satellite at a time
+    std::cout << "Running simulation...\n";
     for (size_t satellite_index = 0;
          satellite_index < input_satellite_vector.size(); satellite_index++) {
       Satellite current_satellite = input_satellite_vector.at(satellite_index);
@@ -636,6 +637,7 @@ void sim_and_plot_orbital_elem_gnuplot(
     }
 
     // now the orbit data, inline, one satellite at a time
+    std::cout << "Running simulation...\n";
     for (size_t satellite_index = 0;
          satellite_index < input_satellite_vector.size(); satellite_index++) {
       Satellite current_satellite = input_satellite_vector.at(satellite_index);
@@ -815,6 +817,7 @@ void sim_and_plot_attitude_evolution_gnuplot(
     }
 
     // now the orbit data, inline, one satellite at a time
+    std::cout << "Running simulation...\n";
     for (size_t satellite_index = 0;
          satellite_index < input_satellite_vector.size(); satellite_index++) {
       Satellite current_satellite = input_satellite_vector.at(satellite_index);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -530,6 +530,7 @@ void sim_and_draw_orbit_gnuplot(std::vector<Satellite> input_satellite_vector,
     }
     fprintf(gnuplot_pipe, "exit \n");
     pclose(gnuplot_pipe);
+    std::cout << "Done\n";
 
   } else {
     std::cout << "gnuplot not found";
@@ -681,6 +682,7 @@ void sim_and_plot_orbital_elem_gnuplot(
 
     fprintf(gnuplot_pipe, "exit \n");
     pclose(gnuplot_pipe);
+    std::cout << "Done\n";
 
   } else {
     std::cout << "gnuplot not found";
@@ -858,6 +860,8 @@ void sim_and_plot_attitude_evolution_gnuplot(
 
     fprintf(gnuplot_pipe, "exit \n");
     pclose(gnuplot_pipe);
+    std::cout << "Done\n";
+
 
   } else {
     std::cout << "gnuplot not found";


### PR DESCRIPTION
# Context
I noticed that some improvements could be made after running the example simulation setup file.

# Changes
- Uncommented 3D plot example
- Added a progress indicator to each simulation/visualization function and one to indicate process termination
- Adjusted inclination of one of the example satellites
- Added a note to simulation_setup to clarify that multiple simulations were being run

# Testing
Needs to pass existing test suites