### PR TITLE
Fixing bug in RK4(5) implementation

### DIFF
--- a/.github/workflows/cmake_gtest_v2.yml
+++ b/.github/workflows/cmake_gtest_v2.yml
@@ -1,5 +1,5 @@
 
-name: Build and run simple unit test(s) on pull request v2
+name: Build and run tests on pull request v2
 
 on:
   pull_request:
@@ -18,7 +18,7 @@ jobs:
     - name: Install gnuplot
       run: sudo apt-get install gnuplot
         
-    - name: Run test suites and generate code coverage report
+    - name: Run test suites
       working-directory: ${{github.workspace}}
       run: |
         rm -rf build

--- a/.github/workflows/cmake_gtest_v2.yml
+++ b/.github/workflows/cmake_gtest_v2.yml
@@ -9,7 +9,7 @@ env:
   BUILD_TYPE: Release
 
 jobs:
-  run_unit_test_suites_v2:
+  run_test_suites_v2:
     runs-on: ubuntu-latest
 
     steps:

--- a/include/utils.h
+++ b/include/utils.h
@@ -155,8 +155,7 @@ std::pair<std::array<double, T>, std::pair<double, double>> RK45_step(
     std::array<double, T> k_vec_at_this_s;
     for (size_t s_ind = 0; s_ind < k_ind; s_ind++) {
       for (size_t y_val_ind = 0; y_val_ind < y_n.size(); y_val_ind++) {
-        y_n_evaluated_value.at(y_val_ind) += input_step_size *
-                                             RK_matrix(k_ind, s_ind) *
+        y_n_evaluated_value.at(y_val_ind) += RK_matrix(k_ind, s_ind) *
                                              k_vec_vec.at(s_ind).at(y_val_ind);
       }
     }

--- a/tests/Satellite_tests.cpp
+++ b/tests/Satellite_tests.cpp
@@ -5,14 +5,14 @@
 #include "Satellite.h"
 #include "utils.h"
 
-const double tolerance = pow(10.0, -7);
+const double tolerance = pow(10.0, -10);
 // Setting a different tolerance for semimajor axis and orbital radius than the other orbital
 // parameters since there appears to be a minimum error associated with
 // converting position and velocity to semimajor axis, best guess is this has to
 // do with the scale of distances and/or velocities being dealt with here
-const double length_tolerance = pow(10.0, -6);
+const double length_tolerance = pow(10.0, -10);
 const double epsilon = pow(10.0, -12);
-const double energy_cons_relative_tolerance = pow(10.0, -5);
+const double energy_cons_relative_tolerance = pow(10.0, -10);
 
 // Elliptical orbit tests
 

--- a/tests/Satellite_tests.cpp
+++ b/tests/Satellite_tests.cpp
@@ -10,7 +10,7 @@ const double tolerance = pow(10.0, -10);
 // parameters since there appears to be a minimum error associated with
 // converting position and velocity to semimajor axis, best guess is this has to
 // do with the scale of distances and/or velocities being dealt with here
-const double length_tolerance = pow(10.0, -10);
+const double length_tolerance = pow(10.0, -7);
 const double epsilon = pow(10.0, -12);
 const double energy_cons_relative_tolerance = pow(10.0, -10);
 


### PR DESCRIPTION
# Context
I noticed that there was an extra factor of the step size in one step of the RK4(5) implementation

# Changes
I removed that factor and changed the tolerances to be lower, since I want to see if these lower tolerances will now pass on the Github Actions workflow

# Testing
Needs to pass test suites